### PR TITLE
Added Upstart Script for Debian based Linux Systems

### DIFF
--- a/unix/agent.conf
+++ b/unix/agent.conf
@@ -1,0 +1,31 @@
+# Simple Upstart Script to make running the agent simpler
+# Tested in Ubuntu 14.04 LTS
+#
+# The directories may need to be adjusted for your installation
+# Expects the binary to be /bin/agent
+# Place the upstart script in /etc/conf/
+# Have agent.cfg and Devices.xml in /etc/mtconnect/
+# NOTE: the script will fail without linux line endings
+# use dos2unix if recieving 'Directory not found' warnings
+
+
+description "MTConnect Agent - Upstart Script"
+author "ellisware.com"
+
+start on runlevel [2345]
+stop on shutdown
+
+script
+ chdir /etc/mtconnect
+ exec bash -c 'bin/agent run /etc/mtconnect/agent.cfg'
+end script
+
+pre-start script
+ echo "['date'] Agent Starting" >> /var/log/agent.log
+end script
+
+pre-stop script
+ rm /var/run/agent.pid
+ echo "['date'] Agent Stopping" >> /var/log/agent.log
+end script
+


### PR DESCRIPTION
Upstart is employed by several major variants of Linux including Debian and Ubuntu as a convenient way of starting and stopping programs with system services. This simple startup script will start the MTConnect Agent with the PC.  This script is an alternative to the Unix daemonize startup script already provided with the MtConnect/cppagent.
