### PR TITLE
Handle period filter in seconds and add tests

### DIFF
--- a/agent/adapter.cpp
+++ b/agent/adapter.cpp
@@ -114,14 +114,17 @@ inline string Adapter::extractTime(const string &time, double &anOffset)
       offset = ((uint64_t) (atof(time.c_str()) * 1000.0)) - mBaseOffset;
     }
     
-    anOffset = offset;
+	// convert microseconds to seconds
+	anOffset = offset / 1000000;
     
     result = getRelativeTimeString(mBaseTime + offset);
   } else if (mIgnoreTimestamps || time.empty()) {
+    anOffset = getCurrentTimeInSec();
     result = getCurrentTime(GMT_UV_SEC);
   }
   else
   {
+    anOffset = parseTimeMicro(time) / 1000000;
     result = time;
   }
   

--- a/agent/data_item.hpp
+++ b/agent/data_item.hpp
@@ -313,6 +313,7 @@ protected:
   bool mHasConstraints;
   
   double mFilterValue;
+  // Period filter, in seconds
   double mFilterPeriod;
   bool mHasMinimumDelta;
   bool mHasMinimumPeriod;

--- a/samples/filter_example_1.3.xml
+++ b/samples/filter_example_1.3.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<MTConnectDevices xmlns:m="urn:mtconnect.org:MTConnectDevices:1.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:mtconnect.org:MTConnectDevices:1.4">
+<!-- Version 1.4 deprecated using filters as a constraint, but the agent still supports for backwards compatability -->
+<MTConnectDevices xmlns:m="urn:mtconnect.org:MTConnectDevices:1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:mtconnect.org:MTConnectDevices:1.3">
   <Header creationTime="2009-03-22T01:50:29+00:00" sender="localhost" instanceId="1237628993" bufferSize="100000" version="1.1"/>
   <Devices>
     <Device uuid="000" name="LinuxCNC" sampleInterval="10.0" id="d">
@@ -13,14 +14,14 @@
             <Rotary name="C" id="c">
               <DataItems>
                 <DataItem type="LOAD" category="SAMPLE" units="PERCENT" nativeUnits="PERCENT" id="c1" name="load">
-                  <Filters>
-                    <Filter type="MINIMUM_DELTA">5.0</Filter>
-                  </Filters>
+                  <Constraints>
+                    <Filter>5.0</Filter>
+                  </Constraints>
                 </DataItem>
                 <DataItem type="POSITION" category="SAMPLE" units="MILLIMETER" nativeUnits="MILLIMETER" id="c2" name="pos">
-                  <Filters>
-                    <Filter type="PERIOD">10.0</Filter>
-                  </Filters>
+                  <Constraints>
+                    <Filter type="MINIMUM_DELTA">10.0</Filter>
+                  </Constraints>
                 </DataItem>
                 <DataItem name="Smode" type="ROTARY_MODE" category="EVENT" id="c3">
                   <Constraints>

--- a/test/agent_test.hpp
+++ b/test/agent_test.hpp
@@ -104,6 +104,7 @@ class AgentTest : public CppUnit::TestFixture
   CPPUNIT_TEST(testDynamicCalibration);
   CPPUNIT_TEST(testInitialTimeSeriesValues);
   CPPUNIT_TEST(testUUIDChange);
+  CPPUNIT_TEST(testFilterValues13);
   CPPUNIT_TEST(testFilterValues);
   CPPUNIT_TEST(testReferences);
   CPPUNIT_TEST(testDiscrete);
@@ -254,8 +255,9 @@ protected:
   void testInitialTimeSeriesValues();
   
   // Filtering
+  void testFilterValues13();
   void testFilterValues();
-  
+
   // Reset Triggered
   void testResetTriggered();
   

--- a/test/xml_parser_test.cpp
+++ b/test/xml_parser_test.cpp
@@ -373,17 +373,17 @@ void XmlParserTest::testNoNamespace()
   CPPUNIT_ASSERT_NO_THROW(a->parseFile("../samples/NoNamespace.xml"));
 }
 
-void XmlParserTest::testFilteredDataItem()
+void XmlParserTest::testFilteredDataItem13()
 {
   delete a; a = NULL;
   try
   {
     a = new XmlParser();
-    mDevices = a->parseFile("../samples/filter_example.xml");
+    mDevices = a->parseFile("../samples/filter_example_1.3.xml");
   }
   catch (exception & e)
   {
-    CPPUNIT_FAIL("Could not locate test xml: ../samples/filter_example.xml");
+    CPPUNIT_FAIL("Could not locate test xml: ../samples/filter_example_1.3.xml");
   }
   
   Device *dev = mDevices[0];
@@ -393,6 +393,30 @@ void XmlParserTest::testFilteredDataItem()
   CPPUNIT_ASSERT(di->hasMinimumDelta());
 }
 
+void XmlParserTest::testFilteredDataItem()
+{
+	delete a; a = NULL;
+	try
+	{
+		a = new XmlParser();
+		mDevices = a->parseFile("../samples/filter_example.xml");
+	}
+	catch (exception & e)
+	{
+		CPPUNIT_FAIL("Could not locate test xml: ../samples/filter_example.xml");
+	}
+
+	Device *dev = mDevices[0];
+	DataItem *di = dev->getDeviceDataItem("c1");
+
+	CPPUNIT_ASSERT_EQUAL(di->getFilterValue(), 5.0);
+	CPPUNIT_ASSERT(di->hasMinimumDelta());
+
+	di = dev->getDeviceDataItem("c2");
+
+	CPPUNIT_ASSERT_EQUAL(di->getFilterPeriod(), 10.0);
+	CPPUNIT_ASSERT(di->hasMinimumPeriod());
+}
 
 void XmlParserTest::testReferences()
 {

--- a/test/xml_parser_test.hpp
+++ b/test/xml_parser_test.hpp
@@ -56,6 +56,7 @@ class XmlParserTest : public CppUnit::TestFixture
   CPPUNIT_TEST(testParseAsset);
   CPPUNIT_TEST(testUpdateAsset);
   CPPUNIT_TEST(testNoNamespace);
+  CPPUNIT_TEST(testFilteredDataItem13);
   CPPUNIT_TEST(testFilteredDataItem);
   CPPUNIT_TEST(testReferences);
   CPPUNIT_TEST(testExtendedAsset);
@@ -83,6 +84,7 @@ protected:
   void testParseOtherAsset();
   void testParseRemovedAsset();
   void testNoNamespace();
+  void testFilteredDataItem13();
   void testFilteredDataItem();
   void testReferences();
   void testExtendedAsset();

--- a/test/xml_printer_test.cpp
+++ b/test/xml_printer_test.cpp
@@ -618,12 +618,12 @@ void XmlPrinterTest::testChangeMTCLocation()
   XmlPrinter::setSchemaVersion("1.3");
 }
 
-void XmlPrinterTest::testProbeWithFilter()
+void XmlPrinterTest::testProbeWithFilter13()
 {
   delete config;
   
   config = new XmlParser();
-  devices = config->parseFile("../samples/filter_example.xml");
+  devices = config->parseFile("../samples/filter_example_1.3.xml");
   
   PARSE_XML(XmlPrinter::printProbe(123, 9999, 1024, 10, 1, devices));
   
@@ -631,6 +631,20 @@ void XmlPrinterTest::testProbeWithFilter()
   CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:DataItem[@name='load']/m:Filters/m:Filter@type", "MINIMUM_DELTA");
 }
 
+void XmlPrinterTest::testProbeWithFilter()
+{
+	delete config;
+
+	config = new XmlParser();
+	devices = config->parseFile("../samples/filter_example.xml");
+
+	PARSE_XML(XmlPrinter::printProbe(123, 9999, 1024, 10, 1, devices));
+
+	CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:DataItem[@name='load']/m:Filters/m:Filter", "5");
+	CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:DataItem[@name='load']/m:Filters/m:Filter@type", "MINIMUM_DELTA");
+	CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:DataItem[@name='pos']/m:Filters/m:Filter", "10");
+	CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:DataItem[@name='pos']/m:Filters/m:Filter@type", "PERIOD");
+}
 
 void XmlPrinterTest::testReferences()
 {

--- a/test/xml_printer_test.hpp
+++ b/test/xml_printer_test.hpp
@@ -74,6 +74,7 @@ class XmlPrinterTest : public CppUnit::TestFixture
   CPPUNIT_TEST(testPrintCuttingTool);
   CPPUNIT_TEST(testChangeVersion);
   CPPUNIT_TEST(testChangeMTCLocation);
+  CPPUNIT_TEST(testProbeWithFilter13);
   CPPUNIT_TEST(testProbeWithFilter);
   CPPUNIT_TEST(testReferences);
   CPPUNIT_TEST(testPrintExtendedCuttingTool);
@@ -132,6 +133,7 @@ protected:
   void testChangeMTCLocation();
   
   // Filter Tests
+  void testProbeWithFilter13();
   void testProbeWithFilter();
   
   // Reference tests


### PR DESCRIPTION
Filters of type period now work regardless of time settings (ignore timestamps, relative time) and follow the standard specification of seconds.
Since version 1.3 and earlier allowed filters to be specified as constraints, and the agent still supports this format, separate tests were created for 1.3 and current version.
Fixes #58.