### PR TITLE
Use InitialValue when reset is triggered

### DIFF
--- a/agent/component_event.cpp
+++ b/agent/component_event.cpp
@@ -72,6 +72,9 @@ ComponentEvent::ComponentEvent(DataItem& dataItem,
     if (splitValue(v, reset))
     {
       mResetTriggered = reset;
+      if (mDataItem->hasInitialValue()) {
+        v = mDataItem->getInitialValue();
+      }
     }
     convertValue(v);
   }

--- a/samples/test_config.xml
+++ b/samples/test_config.xml
@@ -17,7 +17,9 @@
                   <Source>spindle_speed</Source>
                 </DataItem>
                 <DataItem name="Smode" type="ROTARY_MODE" category="EVENT" id="c2">
-                  <Constraints><Value>SPINDLE</Value></Constraints>
+                  <Constraints>
+                    <Value>SPINDLE</Value>
+                  </Constraints>
                 </DataItem>
                 <DataItem type="SPINDLE_SPEED" category="SAMPLE" units="PERCENT" nativeUnits="PERCENT" id="c3" subType="OVERRIDE" name="Sovr">
                   <Source>SspeedOvr</Source>
@@ -43,14 +45,17 @@
             </Linear>
             <Linear name="Y" id="y">
               <DataItems>
-                <DataItem type="POSITION" category="SAMPLE" units="MILLIMETER" nativeUnits="MILLIMETER" id="y1" subType="ACTUAL" name="Yact"/>
+                <DataItem type="POSITION" category="SAMPLE" units="MILLIMETER" nativeUnits="MILLIMETER" id="y1" subType="ACTUAL" name="Yact">
+                  <Filters>
+                    <Filter type="MINIMUM_DELTA">2.0</Filter>
+                  </Filters>
+                </DataItem>
                 <DataItem type="POSITION" category="SAMPLE" units="MILLIMETER" nativeUnits="MILLIMETER" id="y2" subType="COMMANDED" name="Ycom"/>
                 <DataItem type="LOAD" category="CONDITION" id="ylc">
-		  <Filters>
-		    <Filter type="PERIOD">1.0</Filter>
-		    <Filter type="MINIMUM_DELTA">2.0</Filter>
-		  </Filters>
-		</DataItem>
+                  <Filters>
+                    <Filter type="PERIOD">1.0</Filter>
+                  </Filters>
+                </DataItem>
               </DataItems>
             </Linear>
             <Linear name="Z" id="z">
@@ -61,14 +66,14 @@
                 <DataItem type="TEMPERATURE" category="SAMPLE" units="CELCIUS" id="zt1" name="z_motor_temp" compositionId="zmotor"/>
                 <DataItem type="TEMPERATURE" category="SAMPLE" units="CELCIUS" id="zt2" name="z_amp_temp" compositionId="zamp"/>
               </DataItems>
-	      <Compositions>
-		<Composition id="zmotor" type="MOTOR" uuid="12345" name="motor_name">
-		  <Description manufacturer="open" model="vroom" serialNumber="12356" station="A">
-		    Hello There
-		  </Description>
-		</Composition>
-		<Composition id="zamp" type="AMPLIFIER"/>
-	      </Compositions>
+              <Compositions>
+                <Composition id="zmotor" type="MOTOR" uuid="12345" name="motor_name">
+                  <Description manufacturer="open" model="vroom" serialNumber="12356" station="A">
+        Hello There
+                  </Description>
+                </Composition>
+                <Composition id="zamp" type="AMPLIFIER"/>
+              </Compositions>
             </Linear>
           </Components>
         </Axes>
@@ -87,10 +92,13 @@
                 <DataItem type="PATH_POSITION" category="EVENT" id="p6" name="Ppos" />
                 <DataItem type="x:TOOL_GROUP" category="EVENT" id="xp6" name="Ppos" />
                 <DataItem type="MOTION_PROGRAM" category="CONDITION" id="cmp" />
-		<DataItem type="PART_COUNT" category="EVENT" id="pcount">
-		  <InitialValue>0</InitialValue>
-		  <ResetTrigger>DAY</ResetTrigger>
-		</DataItem>
+                <DataItem type="PART_COUNT" category="EVENT" id="pcount">
+                  <InitialValue>0</InitialValue>
+                  <ResetTrigger>DAY</ResetTrigger>
+                </DataItem>
+                <DataItem type="PART_COUNT" subType="REMAINING" category="EVENT" id="pcountrem">
+                  <ResetTrigger>SHIFT</ResetTrigger>
+                </DataItem>
               </DataItems>
             </Path>
           </Components>
@@ -98,15 +106,15 @@
         <Power name="power" id="power">
           <Configuration>
             <SensorConfiguration>
-	      <FirmwareVersion>1.0</FirmwareVersion>
-	      <CalibrationDate>2011-08-10</CalibrationDate>
-	      <CalibrationInitials>WS</CalibrationInitials>
-	      <Channels>
-		<Channel number="1" name="AAA" >
-		  <Description>Power Channel</Description>
-		  <CalibrationDate>2011-08-01</CalibrationDate>
-		</Channel>
-	      </Channels>
+              <FirmwareVersion>1.0</FirmwareVersion>
+              <CalibrationDate>2011-08-10</CalibrationDate>
+              <CalibrationInitials>WS</CalibrationInitials>
+              <Channels>
+                <Channel number="1" name="AAA" >
+                  <Description>Power Channel</Description>
+                  <CalibrationDate>2011-08-01</CalibrationDate>
+                </Channel>
+              </Channels>
             </SensorConfiguration>
           </Configuration>
           <DataItems>

--- a/test/agent_test.cpp
+++ b/test/agent_test.cpp
@@ -294,7 +294,7 @@ void AgentTest::testAddToBuffer()
   
   {
     path = "/sample";
-    PARSE_XML_RESPONSE_QUERY_KV("from", "35");
+    PARSE_XML_RESPONSE_QUERY_KV("from", "36");
     CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:Streams", 0);
   }
   
@@ -2101,8 +2101,8 @@ void AgentTest::testResetTriggered()
   adapter->processData("TIME1|pcount|0");
   adapter->processData("TIME2|pcount|1");
   adapter->processData("TIME3|pcount|2");
-  adapter->processData("TIME4|pcount|0:DAY");
-  adapter->processData("TIME3|pcount|5");
+  adapter->processData("TIME4|pcount|reset:DAY");
+  adapter->processData("TIME5|pcount|5");
 
   {
     PARSE_XML_RESPONSE;
@@ -2116,6 +2116,23 @@ void AgentTest::testResetTriggered()
     CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:DeviceStream//m:PartCount[6]", "5");
   }
   
+  adapter->processData("TIME6|pcountrem|10");
+  adapter->processData("TIME7|pcountrem|9");
+  adapter->processData("TIME8|pcountrem|8");
+  adapter->processData("TIME9|pcountrem|10:SHIFT");
+  adapter->processData("TIME10|pcountrem|9");
+
+  {
+	  PARSE_XML_RESPONSE;
+	  CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:DeviceStream//m:PartCount[@subType='REMAINING'][1]", "UNAVAILABLE");
+	  CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:DeviceStream//m:PartCount[@subType='REMAINING'][2]", "10");
+	  CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:DeviceStream//m:PartCount[@subType='REMAINING'][3]", "9");
+	  CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:DeviceStream//m:PartCount[@subType='REMAINING'][3]@resetTriggered", NULL);
+	  CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:DeviceStream//m:PartCount[@subType='REMAINING'][4]", "8");
+	  CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:DeviceStream//m:PartCount[@subType='REMAINING'][5]", "10");
+	  CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:DeviceStream//m:PartCount[@subType='REMAINING'][5]@resetTriggered", "SHIFT");
+	  CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:DeviceStream//m:PartCount[@subType='REMAINING'][6]", "9");
+  }
 
   
 }

--- a/test/xml_printer_test.cpp
+++ b/test/xml_printer_test.cpp
@@ -125,14 +125,16 @@ void XmlPrinterTest::testPrintDataItemElements()
 {
   PARSE_XML(XmlPrinter::printProbe(123, 9999, 1, 1024, 10, devices));
   
-  CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:DataItem[@id='ylc']/m:Filters/m:Filter[2]@type", "PERIOD");
-  CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:DataItem[@id='ylc']/m:Filters/m:Filter[2]", "1");
+  CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:DataItem[@id='y1']/m:Filters/m:Filter[1]@type", "MINIMUM_DELTA");
+  CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:DataItem[@id='y1']/m:Filters/m:Filter[1]", "2");
 
-  CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:DataItem[@id='ylc']/m:Filters/m:Filter[1]@type", "MINIMUM_DELTA");
-  CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:DataItem[@id='ylc']/m:Filters/m:Filter[1]", "2");
+  CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:DataItem[@id='ylc']/m:Filters/m:Filter[1]@type", "PERIOD");
+  CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:DataItem[@id='ylc']/m:Filters/m:Filter[1]", "1");
 
   CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:DataItem[@id='pcount']/m:InitialValue", "0");
   CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:DataItem[@id='pcount']/m:ResetTrigger", "DAY");
+
+  CPPUNITTEST_ASSERT_XML_PATH_EQUAL(doc, "//m:DataItem[@id='pcountrem']/m:ResetTrigger", "SHIFT");
 }
 
 void XmlPrinterTest::testPrintCurrent()


### PR DESCRIPTION
If initial value is specified, it will be used when a reset is triggered. If not, the value from the adapter is used.
Also, filters adjusted in test_config.xml as standard specifies "Either MINIMUM_DELTA or PERIOD can be defined, not both."

Fixes #59.