### PR TITLE
Set default schema version to 1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,7 +575,7 @@ Configuration Parameters
     
 * `SchemaVersion` - Change the schema version to a different version number.
 
-    *Default*: 1.3
+    *Default*: 1.4
 
 * `ConversionRequired` - Global default for data item units conversion in the agent. 
   Assumes the adapter has already done unit conversion.

--- a/agent/config.cpp
+++ b/agent/config.cpp
@@ -509,7 +509,7 @@ void AgentConfiguration::loadConfig(std::istream &aFile)
     mAgent->getDevices()[i]->mPreserveUuid = defaultPreserve;
   
   if (XmlPrinter::getSchemaVersion().empty())
-    XmlPrinter::setSchemaVersion("1.3");
+    XmlPrinter::setSchemaVersion("1.4");
   
   loadAllowPut(reader);
   loadAdapters(reader, defaultPreserve, legacyTimeout, reconnectInterval, ignoreTimestamps,

--- a/agent/xml_printer.cpp
+++ b/agent/xml_printer.cpp
@@ -41,7 +41,7 @@ static map<string, SchemaNamespace> sDevicesNamespaces;
 static map<string, SchemaNamespace> sStreamsNamespaces;
 static map<string, SchemaNamespace> sErrorNamespaces;
 static map<string, SchemaNamespace> sAssetsNamespaces;
-static string sSchemaVersion("1.3");
+static string sSchemaVersion("1.4");
 static string mStreamsStyle;
 static string mDevicesStyle;
 static string mErrorStyle;


### PR DESCRIPTION
I don't see a reason not to set 1.4 as the default.