### PR TITLE
Converted all #ifdef include guards to #pragma once

### DIFF
--- a/agent/adapter.hpp
+++ b/agent/adapter.hpp
@@ -14,8 +14,7 @@
  *    limitations under the License.
  */
 
-#ifndef ADAPTER_HPP
-#define ADAPTER_HPP
+#pragma once
 
 #include <string>
 #include <sstream>
@@ -157,6 +156,3 @@ private:
   /* Inherited and is run as part of the threaded_object */
   void thread();
 };
-
-#endif
-

--- a/agent/agent.hpp
+++ b/agent/agent.hpp
@@ -14,8 +14,7 @@
  *    limitations under the License.
  */
 
-#ifndef AGENT_HPP
-#define AGENT_HPP
+#pragma once
 
 #include <sstream>
 #include <string>
@@ -375,6 +374,4 @@ protected:
   // For debugging
   bool mLogStreamData;
 };
-
-#endif
 

--- a/agent/asset.hpp
+++ b/agent/asset.hpp
@@ -14,8 +14,7 @@
  *    limitations under the License.
  */
 
-#ifndef ASSET_HPP
-#define ASSET_HPP
+#pragma once
 
 #include <string>
 #include <map>
@@ -84,5 +83,3 @@ public:
 
 typedef std::map<std::string, AssetPtr> AssetIndex;
 
-
-#endif

--- a/agent/change_observer.hpp
+++ b/agent/change_observer.hpp
@@ -14,8 +14,7 @@
  *    limitations under the License.
  */
 
-#ifndef CHANGE_OBSERVER_HPP
-#define CHANGE_OBSERVER_HPP
+#pragma once
 
 #include <vector>
 #include "dlib/threads.h"
@@ -81,5 +80,3 @@ protected:
   dlib::rmutex mObserverMutex;
   std::vector<ChangeObserver*> mObservers;
 };
-
-#endif

--- a/agent/checkpoint.hpp
+++ b/agent/checkpoint.hpp
@@ -14,8 +14,7 @@
  *    limitations under the License.
  */
 
-#ifndef CHECKPOINT_HPP
-#define CHECKPOINT_HPP
+#pragma once
 
 #include "component_event.hpp"
 #include <map>
@@ -46,4 +45,3 @@ protected:
   bool mHasFilter;
 };
 
-#endif

--- a/agent/component.hpp
+++ b/agent/component.hpp
@@ -14,8 +14,7 @@
  *    limitations under the License.
  */
 
-#ifndef COMPONENT_HPP
-#define COMPONENT_HPP
+#pragma once
 
 #include <sstream>
 #include <string>
@@ -197,5 +196,4 @@ struct ComponentComp {
   }
 };
 
-#endif
 

--- a/agent/component_event.hpp
+++ b/agent/component_event.hpp
@@ -14,8 +14,7 @@
  *    limitations under the License.
  */
 
-#ifndef COMPONENT_EVENT_HPP
-#define COMPONENT_EVENT_HPP
+#pragma once
 
 #include <string>
 #include <vector>
@@ -162,5 +161,4 @@ inline void ComponentEvent::appendTo(ComponentEvent *aEvent)
 { 
   mPrev = aEvent; 
 }
-#endif
 

--- a/agent/config.hpp
+++ b/agent/config.hpp
@@ -1,5 +1,4 @@
-#ifndef CONFIG_HPP
-#define CONFIG_HPP
+#pragma once
 
 #include "service.hpp"
 #include <string>
@@ -60,5 +59,3 @@ protected:
   bool mRestart;
   std::string mExePath;
 };
-
-#endif

--- a/agent/connector.hpp
+++ b/agent/connector.hpp
@@ -14,8 +14,7 @@
  *    limitations under the License.
  */
 
-#ifndef CONNECTOR_HPP
-#define CONNECTOR_HPP
+#pragma once
 
 #include "dlib/sockets.h"
 #include "dlib/server.h"
@@ -111,6 +110,3 @@ private:
   /* Size of buffer to read at a time from the socket */  
   static const unsigned int SOCKET_BUFFER_SIZE = 8192;
 };
-
-#endif
-

--- a/agent/cutting_tool.hpp
+++ b/agent/cutting_tool.hpp
@@ -15,8 +15,7 @@
  */
 
 
-#ifndef CUTTING_TOOL_HPP
-#define CUTTING_TOOL_HPP
+#pragma once
 
 #include "asset.hpp"
 #include <vector>
@@ -80,5 +79,3 @@ public:
   std::vector<CuttingItemPtr> mItems;
   std::vector<CuttingToolValuePtr> mLives;
 };
-
-#endif

--- a/agent/data_item.hpp
+++ b/agent/data_item.hpp
@@ -14,8 +14,7 @@
  *    limitations under the License.
  */
 
-#ifndef DATA_ITEM_HPP
-#define DATA_ITEM_HPP
+#pragma once
 
 #include <map>
 
@@ -337,6 +336,3 @@ protected:
   double mConversionOffset;
   bool mConversionDetermined, mConversionRequired, mHasFactor;
 };
-
-#endif
-

--- a/agent/device.hpp
+++ b/agent/device.hpp
@@ -14,8 +14,7 @@
  *    limitations under the License.
  */
 
-#ifndef DEVICE_HPP
-#define DEVICE_HPP
+#pragma once
 
 #include <map>
 
@@ -57,6 +56,3 @@ protected:
   std::map<std::string, DataItem *> mDeviceDataItemsById;
   std::map<std::string, DataItem *> mDeviceDataItemsBySource;
 };
-
-#endif
-

--- a/agent/globals.hpp
+++ b/agent/globals.hpp
@@ -14,8 +14,7 @@
  *    limitations under the License.
  */
 
-#ifndef GLOBALS_HPP
-#define GLOBALS_HPP
+#pragma once
 
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS 1
@@ -141,7 +140,3 @@ typedef volatile long AtomicInt;
 typedef int AtomicInt;
 #endif
 #endif
-
-
-#endif
-

--- a/agent/options.hpp
+++ b/agent/options.hpp
@@ -14,8 +14,7 @@
  *    limitations under the License.
  */
 
-#ifndef OPTIONS_HPP
-#define OPTIONS_HPP
+#pragma once
 
 #include <list>
 #include <string>
@@ -142,6 +141,5 @@ protected:
 // ------------------------ Inline Methods ------------------------------
 // #include <Options.inl>
 
-#endif // Options_H
 
 

--- a/agent/ref_counted.hpp
+++ b/agent/ref_counted.hpp
@@ -14,8 +14,7 @@
  *    limitations under the License.
  */
 
-#ifndef REF_COUNTED_HPP
-#define REF_COUNTED_HPP
+#pragma once
 
 #include <cmath>
 #include "globals.hpp"
@@ -109,6 +108,4 @@ protected:
   /* Reference count */
   AtomicInt mRefCount;
 };
-
-#endif
 

--- a/agent/rolling_file_logger.hpp
+++ b/agent/rolling_file_logger.hpp
@@ -14,8 +14,7 @@
  *    limitations under the License.
  */
 
-#ifndef ROLLING_FILE_LOGGER_HPP
-#define ROLLING_FILE_LOGGER_HPP
+#pragma once
 
 #include "globals.hpp"
 #include <string>
@@ -59,5 +58,3 @@ private:
   
   int mFd;
 };
-
-#endif

--- a/agent/service.hpp
+++ b/agent/service.hpp
@@ -1,5 +1,4 @@
-#ifndef SERVICE_HPP
-#define SERVICE_HPP
+#pragma once
 
 #include <string>
 #include "dlib/logger.h"
@@ -32,5 +31,3 @@ protected:
 #endif
 
 };
-
-#endif

--- a/agent/xml_parser.hpp
+++ b/agent/xml_parser.hpp
@@ -14,8 +14,7 @@
  *    limitations under the License.
  */
 
-#ifndef XML_PARSER_HPP
-#define XML_PARSER_HPP
+#pragma once
 
 #include <list>
 #include <set>
@@ -117,4 +116,3 @@ protected:
   CuttingItemPtr parseCuttingItem(xmlNodePtr aNode, xmlDocPtr aDoc);
 };
 
-#endif

--- a/agent/xml_printer.hpp
+++ b/agent/xml_printer.hpp
@@ -14,8 +14,7 @@
  *    limitations under the License.
  */
 
-#ifndef XML_PRINTER_HPP
-#define XML_PRINTER_HPP
+#pragma once
 
 #include <map>
 #include <list>
@@ -100,6 +99,4 @@ namespace XmlPrinter
   const std::string getStreamsLocation(const std::string &aPrefix);
   const std::string getAssetsLocation(const std::string &aPrefix);
 };
-
-#endif
 

--- a/test/adapter_test.hpp
+++ b/test/adapter_test.hpp
@@ -31,8 +31,7 @@
 * SUCH PARTY HAD ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES.
 */
 
-#ifndef COMPONENT_EVENT_TEST_HPP
-#define COMPONENT_EVENT_TEST_HPP
+#pragma once
 
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS 1
@@ -61,6 +60,3 @@ protected:
 protected:
   void testAdapter();
 };
-
-#endif
-

--- a/test/agent_test.hpp
+++ b/test/agent_test.hpp
@@ -31,8 +31,7 @@
 * SUCH PARTY HAD ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES.
 */
 
-#ifndef AGENT_TEST_HPP
-#define AGENT_TEST_HPP
+#pragma once
 
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS 1
@@ -305,6 +304,4 @@ public:
 #define PARSE_XML_RESPONSE_PUT(body, queries)			    \
   xmlDocPtr doc = putResponseHelper(CPPUNIT_SOURCELINE(), body, queries); \
   CPPUNIT_ASSERT(doc)
-
-#endif
 

--- a/test/asset_test.hpp
+++ b/test/asset_test.hpp
@@ -31,8 +31,7 @@
  * SUCH PARTY HAD ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES.
  */
 
-#ifndef ASSET_TEST_HPP
-#define ASSET_TEST_HPP
+#pragma once
 
 #include <map>
 #include <string>
@@ -58,6 +57,4 @@ protected:
 protected:
   void testAsset();
 };
-
-#endif
 

--- a/test/change_observer_test.hpp
+++ b/test/change_observer_test.hpp
@@ -31,8 +31,7 @@
 * SUCH PARTY HAD ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES.
 */
 
-#ifndef CHANGE_OBSERVER_TEST_HPP
-#define CHANGE_OBSERVER_TEST_HPP
+#pragma once
 
 #include <map>
 #include <string>
@@ -66,5 +65,4 @@ public:
   void tearDown();
 };
 
-#endif
 

--- a/test/checkpoint_test.hpp
+++ b/test/checkpoint_test.hpp
@@ -31,8 +31,7 @@
  * SUCH PARTY HAD ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES.
  */
 
-#ifndef COMPONENT_TEST_HPP
-#define COMPONENT_TEST_HPP
+#pragma once
 
 #include <map>
 #include <string>
@@ -78,5 +77,4 @@ public:
   void tearDown();
 };
 
-#endif
 

--- a/test/component_event_test.hpp
+++ b/test/component_event_test.hpp
@@ -31,8 +31,7 @@
 * SUCH PARTY HAD ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES.
 */
 
-#ifndef COMPONENT_EVENT_TEST_HPP
-#define COMPONENT_EVENT_TEST_HPP
+#pragma once
 
 #include <map>
 #include <string>
@@ -89,6 +88,4 @@ protected:
     CPPUNIT_NS::SourceLine sourceLine
   );
 };
-
-#endif
 

--- a/test/component_test.hpp
+++ b/test/component_test.hpp
@@ -31,8 +31,7 @@
 * SUCH PARTY HAD ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES.
 */
 
-#ifndef COMPONENT_TEST_HPP
-#define COMPONENT_TEST_HPP
+#pragma once
 
 #include <map>
 #include <string>
@@ -71,5 +70,4 @@ public:
   void tearDown();
 };
 
-#endif
 

--- a/test/config_test.hpp
+++ b/test/config_test.hpp
@@ -31,8 +31,7 @@
 * SUCH PARTY HAD ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES.
 */
 
-#ifndef COMPONENT_EVENT_TEST_HPP
-#define COMPONENT_EVENT_TEST_HPP
+#pragma once
 
 #include <map>
 #include <string>
@@ -93,5 +92,4 @@ protected:
   void testMaxSize();
 };
 
-#endif
 

--- a/test/connector_test.hpp
+++ b/test/connector_test.hpp
@@ -31,8 +31,7 @@
 * SUCH PARTY HAD ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES.
 */
 
-#ifndef COMPONENT_EVENT_TEST_HPP
-#define COMPONENT_EVENT_TEST_HPP
+#pragma once
 
 #include <map>
 #include <string>
@@ -122,5 +121,4 @@ protected:
   void testStartHeartbeats();
 };
 
-#endif
 

--- a/test/cutting_tool_test.hpp
+++ b/test/cutting_tool_test.hpp
@@ -31,8 +31,7 @@
  * SUCH PARTY HAD ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES.
  */
 
-#ifndef CUTTING_TOOL_TEST_HPP
-#define CUTTING_TOOL_TEST_HPP
+#pragma once
 
 #include <map>
 #include <string>
@@ -59,5 +58,4 @@ protected:
   void testCuttingTool();
 };
 
-#endif
 

--- a/test/data_item_test.hpp
+++ b/test/data_item_test.hpp
@@ -31,8 +31,7 @@
 * SUCH PARTY HAD ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES.
 */
 
-#ifndef DATA_ITEM_TEST_HPP
-#define DATA_ITEM_TEST_HPP
+#pragma once
 
 #include <map>
 #include <string>
@@ -84,6 +83,3 @@ public:
   void setUp();
   void tearDown();
 };
-
-#endif
-

--- a/test/device_test.hpp
+++ b/test/device_test.hpp
@@ -31,8 +31,7 @@
 * SUCH PARTY HAD ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES.
 */
 
-#ifndef DEVICE_TEST_HPP
-#define DEVICE_TEST_HPP
+#pragma once
 
 #include <map>
 #include <string>
@@ -73,5 +72,4 @@ public:
   void tearDown();
 };
 
-#endif
 

--- a/test/globals_test.hpp
+++ b/test/globals_test.hpp
@@ -31,8 +31,7 @@
 * SUCH PARTY HAD ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES.
 */
 
-#ifndef GLOBALS_TEST_HPP
-#define GLOBALS_TEST_HPP
+#pragma once
 
 #include <map>
 #include <string>
@@ -76,5 +75,4 @@ public:
   void tearDown();
 };
 
-#endif
 

--- a/test/test_globals.hpp
+++ b/test/test_globals.hpp
@@ -31,6 +31,8 @@
 * SUCH PARTY HAD ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES.
 */
 
+#pragma once
+
 #include <sstream>
 #include <fstream>
 #include <string>

--- a/test/xml_parser_test.hpp
+++ b/test/xml_parser_test.hpp
@@ -31,8 +31,7 @@
 * SUCH PARTY HAD ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES.
 */
 
-#ifndef XML_PARSER_TEST_HPP
-#define XML_PARSER_TEST_HPP
+#pragma once
 
 #include <cppunit/TestFixture.h>
 #include <cppunit/extensions/HelperMacros.h>
@@ -95,6 +94,3 @@ public:
   void setUp();
   void tearDown();
 };
-
-#endif
-

--- a/test/xml_printer_test.hpp
+++ b/test/xml_printer_test.hpp
@@ -31,8 +31,7 @@
 * SUCH PARTY HAD ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES.
 */
 
-#ifndef XML_PRINTER_TEST_HPP
-#define XML_PRINTER_TEST_HPP
+#pragma once
 
 #include <string>
 #include <fstream>
@@ -167,6 +166,3 @@ public:
   void setUp();
   void tearDown();
 };
-
-#endif
-


### PR DESCRIPTION
This is a more convenient syntax and is less error prone (supported by all modern compilers)