### PR TITLE
Use of C++ 11 'override' keyword

### DIFF
--- a/agent/adapter.hpp
+++ b/agent/adapter.hpp
@@ -101,12 +101,12 @@ public:
 		m_baseTime = offset; }
 
 	// Inherited method to incoming data from the server
-	virtual void processData(const std::string &data);
-	virtual void protocolCommand(const std::string &data);
+	void processData(const std::string &data) override;
+	void protocolCommand(const std::string &data) override;
 
 	// Method called when connection is lost.
-	virtual void disconnected();
-	virtual void connected();
+	void disconnected() override;
+	void connected() override;
 
 	bool isDuplicate(DataItem *dataItem, const std::string &value, double timeOffset) const
 	{
@@ -185,5 +185,5 @@ protected:
 
 private:
 	// Inherited and is run as part of the threaded_object
-	void thread();
+	void thread() override;
 };

--- a/agent/agent.hpp
+++ b/agent/agent.hpp
@@ -110,9 +110,9 @@ public:
 	virtual ~Agent();
 
 	// Overridden method that is called per web request
-	virtual const std::string on_request(
+	const std::string on_request (
 		const incoming_things &incoming,
-		outgoing_things &outgoing );
+		outgoing_things &outgoing ) override;
 
 	// Add an adapter to the agent
 	Adapter *addAdapter(const std::string &device,

--- a/agent/config.hpp
+++ b/agent/config.hpp
@@ -34,9 +34,9 @@ public:
 	virtual ~AgentConfiguration();
 
 	// For MTConnectService
-	virtual void stop();
-	virtual void start() ;
-	virtual void initialize(int aArgc, const char *aArgv[]);
+	void stop() override;
+	void start() override;
+	void initialize(int argc, const char *argv[]) override;
 
 	void configureLogger(dlib::config_reader::kernel_1a &reader);
 	void loadConfig(std::istream &file);

--- a/agent/cutting_tool.hpp
+++ b/agent/cutting_tool.hpp
@@ -87,12 +87,12 @@ public:
 	}
 	~CuttingTool();
 
-	virtual void addIdentity(const std::string &key, const std::string &value);
+	void addIdentity(const std::string &key, const std::string &value) override;
 	void addValue(const CuttingToolValuePtr value);
 	void updateValue(const std::string &key, const std::string &value);
 
-	virtual std::string &getContent();
-	virtual void changed() {
+	std::string &getContent() override;
+	void changed() override {
 		m_content.clear(); }
 
 public:

--- a/test/connector_test.hpp
+++ b/test/connector_test.hpp
@@ -56,20 +56,20 @@ public:
 	{
 	}
 
-	virtual void processData(const std::string &data)
+	void processData(const std::string &data) override
 	{
 		m_data = data;
 		m_list.push_back(m_data);
 	}
 
-	virtual void protocolCommand(const std::string &data)
+	void protocolCommand(const std::string &data) override
 	{
 		m_command = data;
 	}
 
-	virtual void disconnected() {
+	void disconnected() override {
 		m_disconnected = true; }
-	virtual void connected() {
+	void connected() override {
 		m_disconnected = false; }
 	bool heartbeats() {
 		return m_heartbeats; }


### PR DESCRIPTION
* Added the 'override' keyword to methods that should be overriding the behavior of a base class or implementing an abstract base class method
* This keyword allows the compiler the chance to spot when a virtual base class function has changed by the derived classes have not been updated