### PR TITLE
C++11 loops and threads

### DIFF
--- a/agent/adapter.cpp
+++ b/agent/adapter.cpp
@@ -19,6 +19,8 @@
 #include "globals.hpp"
 #include "dlib/logger.h"
 #include <algorithm>
+#include <chrono>
+#include <thread>
 
 using namespace std;
 
@@ -543,7 +545,7 @@ void Adapter::thread()
 
 		// Try to reconnect every 10 seconds
 		g_logger << LINFO << "Will try to reconnect in " << m_reconnectInterval << " milliseconds";
-		dlib::sleep(m_reconnectInterval);
+		this_thread::sleep_for(chrono::milliseconds(m_reconnectInterval));
 	}
 	g_logger << LINFO << "Adapter thread stopped";
 }

--- a/agent/agent.cpp
+++ b/agent/agent.cpp
@@ -19,6 +19,8 @@
 #include <fcntl.h>
 #include <sstream>
 #include <stdexcept>
+#include <chrono>
+#include <thread>
 #include <dlib/tokenizer.h>
 #include <dlib/misc_api.h>
 #include <dlib/array.h>
@@ -1346,7 +1348,7 @@ void Agent::streamData(
 		
 				// For replaying of events, we will stream as fast as we can with a 1ms sleep
 				// to allow other threads to run.
-				dlib::sleep(1);
+				this_thread::sleep_for(1ms);
 			}
 			else
 			{
@@ -1397,7 +1399,7 @@ void Agent::streamData(
 				if (delta < interMicros)
 				{
 					// Sleep the remainder
-					dlib::sleep((interMicros - delta) / 1000);
+					this_thread::sleep_for(chrono::milliseconds((interMicros - delta) / 1000ull));
 				}
 			}
 		}

--- a/agent/agent.cpp
+++ b/agent/agent.cpp
@@ -60,15 +60,14 @@ Agent::Agent(
 		// Load the configuration for the Agent
 		m_xmlParser = new XmlParser();
 		m_devices = m_xmlParser->parseFile(configXmlPath);
-		std::vector<Device *>::iterator device;
 		std::set<std::string> uuids;
-		for (device = m_devices.begin(); device != m_devices.end(); ++device)
+		for (const auto &device : m_devices)
 		{
-			if (uuids.count((*device)->getUuid()) > 0)
-				throw runtime_error("Duplicate UUID: " + (*device)->getUuid());
+			if (uuids.count(device->getUuid()) > 0)
+				throw runtime_error("Duplicate UUID: " + device->getUuid());
 
-			uuids.insert((*device)->getUuid());
-			(*device)->resolveReferences();
+			uuids.insert(device->getUuid());
+			device->resolveReferences();
 		}
 	}
 	catch (runtime_error & e)
@@ -112,61 +111,59 @@ Agent::Agent(
 
 	// Add the devices to the device map and create availability and 
 	// asset changed events if they don't exist
-	std::vector<Device *>::iterator device;
-
-	for (device = m_devices.begin(); device != m_devices.end(); ++device)
+	for (const auto device  : m_devices)
 	{
-		m_deviceMap[(*device)->getName()] = *device;
+		m_deviceMap[device->getName()] = device;
 
 		// Make sure we have two device level data items:
 		// 1. Availability
 		// 2. AssetChanged
-		if (!(*device)->getAvailability())
+		if ( !device->getAvailability() )
 		{
 			// Create availability data item and add it to the device.
 			std::map<string, string> attrs;
 			attrs["type"] = "AVAILABILITY";
-			attrs["id"] = (*device)->getId() + "_avail";
+			attrs["id"] = device->getId() + "_avail";
 			attrs["category"] = "EVENT";
 
 			auto di = new DataItem(attrs);
-			di->setComponent(*(*device));
-			(*device)->addDataItem(*di);
-			(*device)->addDeviceDataItem(*di);
-			(*device)->m_availabilityAdded = true;
+			di->setComponent(*device);
+			device->addDataItem(*di);
+			device->addDeviceDataItem(*di);
+			device->m_availabilityAdded = true;
 		}
 
 		int major, minor;
 		char c;
 		stringstream ss(XmlPrinter::getSchemaVersion());
 		ss >> major >> c >> minor;
-
-		if (!(*device)->getAssetChanged() && (major > 1 || (major == 1 && minor >= 2)))
+		if ( !device->getAssetChanged() && 
+			(major > 1 || (major == 1 && minor >= 2)) )
 		{
 			// Create asset change data item and add it to the device.
 			std::map<string,string> attrs;
 			attrs["type"] = "ASSET_CHANGED";
-			attrs["id"] = (*device)->getId() + "_asset_chg";
+			attrs["id"] = device->getId() + "_asset_chg";
 			attrs["category"] = "EVENT";
-
 			auto di = new DataItem(attrs);
-			di->setComponent(*(*device));
-			(*device)->addDataItem(*di);
-			(*device)->addDeviceDataItem(*di);
+			di->setComponent(*device);
+			device->addDataItem(*di);
+			device->addDeviceDataItem(*di);
 		}
 
-		if (!(*device)->getAssetRemoved() && (major > 1 || (major == 1 && minor >= 3)))
+		if ( !device->getAssetRemoved() &&
+			(major > 1 || (major == 1 && minor >= 3)) )
 		{
 			// Create asset removed data item and add it to the device.
 			std::map<string, string> attrs;
 			attrs["type"] = "ASSET_REMOVED";
-			attrs["id"] = (*device)->getId() + "_asset_rem";
+			attrs["id"] = device->getId() + "_asset_rem";
 			attrs["category"] = "EVENT";
 
 			auto di = new DataItem(attrs);
-			di->setComponent(*(*device));
-			(*device)->addDataItem(*di);
-			(*device)->addDeviceDataItem(*di);
+			di->setComponent(*device);
+			device->addDataItem(*di);
+			device->addDeviceDataItem(*di);
 		}
 	}
 
@@ -181,17 +178,15 @@ Agent::Agent(
 			m_devices) );
 
 	// Initialize the id mapping for the devices and set all data items to UNAVAILABLE
-	for (device = m_devices.begin(); device != m_devices.end(); ++device)
+	for (const auto device : m_devices)
 	{
-		const auto &items = (*device)->getDeviceDataItems();
-		std::map<string, DataItem *>::const_iterator item;
+		const auto &items = device->getDeviceDataItems();
 
-		for (item = items.begin(); item != items.end(); ++item)
+		for (const auto item : items)
 		{
 			// Check for single valued constrained data items.
-			auto d = item->second;
+			auto d = item.second;
 			const string *value = &g_unavailable;
-
 			if (d->isCondition())
 				value = &g_conditionUnavailable;
 			else if (d->hasConstantValue())
@@ -203,8 +198,8 @@ Agent::Agent(
 			else
 			{
 				g_logger << LFATAL << "Duplicate DataItem id " << d->getId() <<
-					" for device: " << (*device)->getName() << " and data item name: " <<
-					d->getName();
+							" for device: " << device->getName() << " and data item name: " <<
+							d->getName();
 				std::exit(1);
 			}
 		}
@@ -243,10 +238,8 @@ void Agent::start()
 	try
 	{
 		// Start all the adapters
-		std::vector<Adapter *>::iterator iter;
-
-		for (iter = m_adapters.begin(); iter != m_adapters.end(); iter++)
-			(*iter)->start();
+		for (const auto adapter : m_adapters)
+			adapter->start();
 
 		// Start the server. This blocks until the server stops.
 		server_http::start();
@@ -262,23 +255,19 @@ void Agent::start()
 void Agent::clear()
 {
 	// Stop all adapter threads...
-	std::vector<Adapter *>::iterator iter;
-
 	g_logger << LINFO << "Shutting down adapters";
-
 	// Deletes adapter and waits for it to exit.
-	for (iter = m_adapters.begin(); iter != m_adapters.end(); iter++)
-		(*iter)->stop();
+	for (const auto adapter : m_adapters)
+		adapter->stop();
 
 	g_logger << LINFO << "Shutting down server";
 	server::http_1a::clear();
 	g_logger << LINFO << "Shutting completed";
 
-	for (iter = m_adapters.begin(); iter != m_adapters.end(); iter++)
-		delete (*iter);
+	for (const auto adapter : m_adapters)
+		delete adapter;
 
 	m_adapters.clear();
-
 }
 
 
@@ -408,7 +397,6 @@ const string Agent::on_request(const incoming_things &incoming, outgoing_things 
 		if (first == "assets" || first == "asset")
 		{
 			string list;
-
 			if (loc1 != string::npos)
 				list = path.substr(loc1 + 1);
 
@@ -602,17 +590,15 @@ bool Agent::addAsset(
 			m_assetMap.erase(oldref->getAssetId());
 
 			// Remove secondary keys
-			auto &keys = oldref->getKeys();
-			AssetKeys::iterator iter;
-			for (iter = keys.begin(); iter != keys.end(); iter++)
+			const auto &keys = oldref->getKeys();
+			for (const auto &key : keys)
 			{
-				AssetIndex &index = m_assetIndices[iter->first];
-				index.erase(iter->second);
+				auto &index = m_assetIndices[key.first];
+				index.erase(key.second);
 			}
 		}
 
 		m_assetMap[id] = ptr;
-
 		if (!ptr->isRemoved())
 		{
 			AssetPtr &newPtr = m_assetMap[id];
@@ -620,12 +606,11 @@ bool Agent::addAsset(
 		}
 
 		// Add secondary keys
-		auto &keys = ptr->getKeys();
-		AssetKeys::iterator iter;
-		for (iter = keys.begin(); iter != keys.end(); iter++)
+		const auto &keys = ptr->getKeys();
+		for (const auto &key : keys)
 		{
-			auto &index = m_assetIndices[iter->first];
-			index[iter->second] = ptr;
+			auto &index = m_assetIndices[key.first];
+			index[key.second] = ptr;
 		}
 	}
 
@@ -667,14 +652,12 @@ bool Agent::updateAsset(
 
 		try
 		{
-			AssetChangeList::iterator iter;
-
-			for (iter = assetChangeList.begin(); iter != assetChangeList.end(); ++iter)
+			for (const auto & assetChange : assetChangeList)
 			{
-				if (iter->first == "xml")
-					m_xmlParser->updateAsset(asset, asset->getType(), iter->second);
+				if (assetChange.first == "xml")
+					m_xmlParser->updateAsset(asset, asset->getType(), assetChange.second);
 				else
-					tool->updateValue(iter->first, iter->second);
+					tool->updateValue(assetChange.first, assetChange.second);
 			}
 		}
 		catch (runtime_error &e)
@@ -715,7 +698,6 @@ bool Agent::removeAsset(
 		dlib::auto_mutex lock(*m_assetLock);
 
 		asset = m_assetMap[id];
-
 		if (!asset.getObject())
 			return false;
 
@@ -781,28 +763,23 @@ void Agent::disconnected(Adapter *adapter, std::vector<Device*> devices)
 	auto time = getCurrentTime(GMT_UV_SEC);
 	g_logger << LDEBUG << "Disconnected from adapter, setting all values to UNAVAILABLE";
 
-	std::vector<Device *>::iterator iter;
-
-	for (iter = devices.begin(); iter != devices.end(); ++iter)
+	for (const auto device : devices)
 	{
-		const auto &dataItems = (*iter)->getDeviceDataItems();
-		std::map<std::string, DataItem *>::const_iterator dataItemAssoc;
-
-		for (dataItemAssoc = dataItems.begin(); dataItemAssoc != dataItems.end(); ++dataItemAssoc)
+		const auto &dataItems = device->getDeviceDataItems();
+		for (const auto & dataItemAssoc : dataItems)
 		{
-			auto dataItem = (*dataItemAssoc).second;
-
+			auto dataItem = dataItemAssoc.second;
 			if (dataItem &&
-				(dataItem->getDataSource() == adapter || (adapter->isAutoAvailable() &&
-				!dataItem->getDataSource() &&
-				dataItem->getType() == "AVAILABILITY")))
+				(dataItem->getDataSource() == adapter ||
+				( adapter->isAutoAvailable() &&
+				  !dataItem->getDataSource() &&
+				  dataItem->getType() == "AVAILABILITY") ) )
 			{
 				auto ptr = m_latest.getEventPtr(dataItem->getId());
 
 				if (ptr)
 				{
 					const string *value = nullptr;
-
 					if (dataItem->isCondition())
 					{
 						if ((*ptr)->getLevel() != ComponentEvent::UNAVAILABLE)
@@ -811,7 +788,6 @@ void Agent::disconnected(Adapter *adapter, std::vector<Device*> devices)
 					else if (dataItem->hasConstraints())
 					{
 						const auto &values = dataItem->getConstrainedValues();
-
 						if (values.size() > 1 && (*ptr)->getValue() != g_unavailable)
 							value = &g_unavailable;
 					}
@@ -824,7 +800,7 @@ void Agent::disconnected(Adapter *adapter, std::vector<Device*> devices)
 				}
 			}
 			else if (!dataItem)
-				g_logger << LWARN << "No data Item for " << (*dataItemAssoc).first;
+				g_logger << LWARN << "No data Item for " << dataItemAssoc.first;
 		}
 	}
 }
@@ -832,23 +808,21 @@ void Agent::disconnected(Adapter *adapter, std::vector<Device*> devices)
 
 void Agent::connected(Adapter *adapter, std::vector<Device *> devices)
 {
-	if (adapter->isAutoAvailable())
+	if (!adapter->isAutoAvailable())
+		return;
+
+	auto time = getCurrentTime(GMT_UV_SEC);
+	for (const auto device : devices)
 	{
-		auto time = getCurrentTime(GMT_UV_SEC);
-		std::vector<Device *>::iterator iter;
+		g_logger << LDEBUG << "Connected to adapter, setting all Availability data items to AVAILABLE";
 
-		for (iter = devices.begin(); iter != devices.end(); ++iter)
+		if (device->getAvailability() )
 		{
-			g_logger << LDEBUG << "Connected to adapter, setting all Availability data items to AVAILABLE";
-
-			if ((*iter)->getAvailability())
-			{
-				g_logger << LDEBUG << "Adding availabilty event for " << (*iter)->getAvailability()->getId();
-				addToBuffer((*iter)->getAvailability(), g_available, time);
-			}
-			else
-				g_logger << LDEBUG << "Cannot find availability for " << (*iter)->getName();
+			g_logger << LDEBUG << "Adding availabilty event for " << device->getAvailability()->getId();
+			addToBuffer(device->getAvailability(), g_available, time);
 		}
+		else
+			g_logger << LDEBUG << "Cannot find availability for " << device->getName();
 	}
 }
 
@@ -957,38 +931,31 @@ string Agent::handlePut(
 	// First check if this is an adapter put or a data put...
 	if (queries["_type"] == "command")
 	{
-		std::vector<Adapter *>::iterator adpt;
-
-		for (adpt = dev->m_adapters.begin(); adpt != dev->m_adapters.end(); adpt++)
+		for (const auto adpt : dev->m_adapters)
 		{
-			key_value_map::const_iterator kv;
-
-			for (kv = queries.begin(); kv != queries.end(); kv++)
+			for (const auto & kv : queries)
 			{
-				string command = kv->first + "=" + kv->second;
+				string command = kv.first + "=" + kv.second;
 				g_logger << LDEBUG << "Sending command '" << command << "' to " << device;
-				(*adpt)->sendCommand(command);
+				adpt->sendCommand(command);
 			}
 		}
 	}
 	else
 	{
 		string time = queries["time"];
-
 		if (time.empty())
 			time = getCurrentTime(GMT_UV_SEC);
 
-		key_value_map::const_iterator kv;
-
-		for (kv = queries.begin(); kv != queries.end(); kv++)
+		for (const auto & kv : queries)
 		{
-			if (kv->first != "time")
+			if (kv.first != "time") 
 			{
-				auto di = dev->getDeviceDataItem(kv->first);
+				auto di = dev->getDeviceDataItem(kv.first);
 				if (di)
-					addToBuffer(di, kv->second, time);
+					addToBuffer(di, kv.second, time);
 				else
-					g_logger << LWARN << "(" << device << ") Could not find data item: " << kv->first;
+					g_logger << LWARN << "(" << device << ") Could not find data item: " << kv.first;
 			}
 		}
 	}
@@ -1267,9 +1234,8 @@ void Agent::streamData(
 	ChangeObserver observer;
 
 	// Add observers
-	std::set<string>::iterator iter;
-	for (iter = filterSet.begin(); iter != filterSet.end(); ++iter)
-		m_dataItemMap[*iter]->addObserver(&observer);
+	for (const auto &item : filterSet)
+		m_dataItemMap[item]->addObserver(&observer);
 
 	uint64_t interMicros = interval * 1000u;
 	uint64_t firstSeq = getFirstSequence();

--- a/agent/component.cpp
+++ b/agent/component.cpp
@@ -137,18 +137,17 @@ void Component::resolveReferences()
 {
 	Device *device = getDevice();
 
-	std::list<Reference>::iterator iter;
-	for (iter = m_references.begin(); iter != m_references.end(); iter++)
+	for (auto &reference : m_references)
 	{
-		auto di = device->getDeviceDataItem(iter->m_id);
+		auto di = device->getDeviceDataItem(reference.m_id);
 
 		if (!di)
-			throw runtime_error("Cannot resolve Reference for component " + m_name + " to data item " + iter->m_id);
+			throw runtime_error("Cannot resolve Reference for component " + m_name + " to data item " +	reference.m_id);
 
-		iter->m_dataItem = di;
+		reference.m_dataItem = di;
 	}
 
-	std::list<Component *>::iterator comp;
-	for (comp = m_children.begin(); comp != m_children.end(); comp++)
-		(*comp)->resolveReferences();
+
+	for (const auto childComponent : m_children)
+		childComponent->resolveReferences();
 }

--- a/agent/config.cpp
+++ b/agent/config.cpp
@@ -22,6 +22,8 @@
 #include <sstream>
 #include <fstream>
 #include <vector>
+#include <chrono>
+#include <thread>
 #include <dlib/config_reader.h>
 #include <dlib/logger.h>
 #include <stdexcept>
@@ -215,7 +217,7 @@ void AgentConfiguration::monitorThread()
 	// Check every 10 seconds
 	do
 	{
-		dlib::sleep(10000);
+		this_thread::sleep_for(10s);
 
 		struct stat devices, cfg;
 		bool check = true;

--- a/agent/config.cpp
+++ b/agent/config.cpp
@@ -528,7 +528,7 @@ void AgentConfiguration::loadConfig(std::istream &file)
 
 	m_devicesFile.clear();
 
-	for (string probe : devices_files)
+	for (const auto &probe : devices_files)
 	{
 		struct stat buf;
 		g_logger << LDEBUG << "Checking for Devices XML configuration file: " << probe;
@@ -558,7 +558,6 @@ void AgentConfiguration::loadConfig(std::istream &file)
 
 	// Check for schema version
 	string schemaVersion = get_with_default(reader, "SchemaVersion", "");
-
 	if (!schemaVersion.empty())
 		XmlPrinter::setSchemaVersion(schemaVersion);
 
@@ -622,15 +621,14 @@ void AgentConfiguration::loadAdapters(
 		std::vector<string> blocks;
 		adapters.get_blocks(blocks);
 
-		std::vector<string>::iterator block;
-		for (block = blocks.begin(); block != blocks.end(); ++block)
+		for (const auto &block : blocks)
 		{
-			const auto &adapter = adapters.block(*block);
+			const auto &adapter = adapters.block(block);
 			string deviceName;
 			if (adapter.is_key_defined("Device"))
 				deviceName = adapter["Device"].c_str();
 			else
-				deviceName = *block;
+				deviceName = block;
 
 			device = m_agent->getDeviceByName(deviceName);
 
@@ -758,14 +756,12 @@ void AgentConfiguration::loadNamespace(
 		std::vector<string> blocks;
 		namespaces.get_blocks(blocks);
 
-		std::vector<string>::iterator block;
-		for (block = blocks.begin(); block != blocks.end(); ++block)
+		for (const auto &block : blocks)
 		{
-			const auto &ns = namespaces.block(*block);
-
-			if (*block != "m" && !ns.is_key_defined("Urn"))
+			const auto &ns = namespaces.block(block);
+			if (block != "m" && !ns.is_key_defined("Urn"))
 			{
-				g_logger << LERROR << "Name space must have a Urn: " << *block;
+				g_logger << LERROR << "Name space must have a Urn: " << block;
 			}
 			else
 			{
@@ -774,7 +770,7 @@ void AgentConfiguration::loadNamespace(
 					location = ns["Location"];
 				if (ns.is_key_defined("Urn"))
 					urn = ns["Urn"];
-				(*callback)(urn, location, *block);
+				(*callback)(urn, location, block);
 				if (ns.is_key_defined("Path") && !location.empty())
 					m_agent->registerFile(location, ns["Path"]);
 			}
@@ -790,19 +786,18 @@ void AgentConfiguration::loadFiles(dlib::config_reader::kernel_1a &reader)
 		const auto &files = reader.block("Files");
 		std::vector<string> blocks;
 		files.get_blocks(blocks);
-
-		std::vector<string>::iterator block;
-		for (block = blocks.begin(); block != blocks.end(); ++block)
+	
+		for (const auto &block : blocks)
 		{
-			const auto &file = files.block(*block);
-
+			const auto &file = files.block(block);
 			if (!file.is_key_defined("Location") || !file.is_key_defined("Path"))
-				g_logger << LERROR << "Name space must have a Location (uri) or Directory and Path: " << *block;
+				g_logger << LERROR << "Name space must have a Location (uri) or Directory and Path: " << block;
 			else
 				m_agent->registerFile(file["Location"], file["Path"]);
 		}
 	}
 }
+
 
 void AgentConfiguration::loadStyle(dlib::config_reader::kernel_1a &reader, const char *styleName, StyleFunction *styleFunction)
 {
@@ -830,9 +825,7 @@ void AgentConfiguration::loadTypes(dlib::config_reader::kernel_1a &reader)
 		std::vector<string> keys;
 		types.get_keys(keys);
 
-		std::vector<string>::iterator key;
-
-		for (key = keys.begin(); key != keys.end(); ++key)
-			m_agent->addMimeType(*key, types[*key]);
+		for (const auto &key : keys)
+			m_agent->addMimeType(key, types[key]);
 	}
 }

--- a/agent/globals.cpp
+++ b/agent/globals.cpp
@@ -72,7 +72,7 @@ string floatToString(double f)
 
 string toUpperCase(string &text)
 {
-	for (unsigned int i = 0; i < text.length(); i++)
+	for (auto i = 0u; i < text.length(); i++)
 		text[i] = toupper(text[i]);
 
 	return text;
@@ -81,7 +81,7 @@ string toUpperCase(string &text)
 
 bool isNonNegativeInteger(const string &s)
 {
-	for (unsigned int i = 0; i < s.length(); i++)
+	for (auto i = 0u; i < s.length(); i++)
 	{
 		if (!isdigit(s[i]))
 			return false;
@@ -209,7 +209,7 @@ unsigned int getCurrentTimeInSec()
 
 void replaceIllegalCharacters(string &data)
 {
-	for (unsigned int i = 0; i < data.length(); i++)
+	for (auto i = 0u; i < data.length(); i++)
 	{
 		char c = data[i];
 
@@ -233,7 +233,7 @@ void replaceIllegalCharacters(string &data)
 
 int getEnumeration(const string &name, const string *array, unsigned int size)
 {
-	for (unsigned int i = 0; i < size; i++)
+	for (auto i = 0u; i < size; i++)
 	{
 		if (name == array[i])
 			return i;

--- a/agent/options.cpp
+++ b/agent/options.cpp
@@ -446,7 +446,7 @@ int OptionsList::parse(int &argc, const char **argv)
 		argc--;
 	}
 
-	for (list<Option>::iterator iter = begin(); iter != end(); iter++)
+	for (auto iter = begin(); iter != end(); iter++)
 	{
 		opt = &(*iter);
 
@@ -499,7 +499,7 @@ void OptionsList::usage()
 
 	bool hasSimpleFlags = false;
 
-	for (list<Option>::iterator iter = begin(); iter != end(); iter++)
+	for (auto iter = begin(); iter != end(); iter++)
 	{
 		Option *opt = &(*iter);
 
@@ -517,7 +517,7 @@ void OptionsList::usage()
 		*cp++ = '[';
 		*cp++ = '-';
 
-		for (list<Option>::iterator iter = begin(); iter != end(); iter++)
+		for (auto iter = begin(); iter != end(); iter++)
 		{
 			Option *opt = &(*iter);
 
@@ -535,7 +535,7 @@ void OptionsList::usage()
 
 	char staging[128], *cp2;
 
-	for (list<Option>::iterator iter = begin(); iter != end(); iter++)
+	for (auto iter = begin(); iter != end(); iter++)
 	{
 		Option *opt = &(*iter);
 
@@ -600,7 +600,7 @@ void OptionsList::usage()
 	fputs(buffer, stderr);
 
 
-	for (list<Option>::iterator iter = begin(); iter != end(); iter++)
+	for (auto iter = begin(); iter != end(); iter++)
 	{
 		Option *opt = &(*iter);
 
@@ -651,7 +651,7 @@ void OptionsList::usage()
 
 bool OptionsList::find(const char *optName, Option *&option)
 {
-	for (list<Option>::iterator iter = begin(); iter != end(); iter++)
+	for (auto iter = begin(); iter != end(); iter++)
 	{
 		option = &(*iter);
 		const char *name = option->getName();
@@ -677,7 +677,7 @@ bool OptionsList::find(const char *optName, Option *&option)
 
 bool OptionsList::find(int order, Option *&option)
 {
-	for (list<Option>::iterator iter = begin(); iter != end(); iter++)
+	for (auto iter = begin(); iter != end(); iter++)
 	{
 		option = &(*iter);
 

--- a/test/agent_test.cpp
+++ b/test/agent_test.cpp
@@ -34,6 +34,8 @@
 #include <stdexcept>
 #include <iostream>
 #include <sstream>
+#include <chrono>
+#include <thread>
 #include <cppunit/portability/Stream.h>
 #include <dlib/server.h>
 
@@ -1808,7 +1810,7 @@ void AgentTest::testPutBlockingFrom()
 void AgentTest::killThread(void *aArg)
 {
   AgentTest *test = (AgentTest*) aArg;
-  dlib::sleep(test->m_delay);
+	this_thread::sleep_for(chrono::milliseconds(test->m_delay));
   test->m_out.setstate(ios::eofbit);
 }
 
@@ -1816,7 +1818,7 @@ void AgentTest::killThread(void *aArg)
 void AgentTest::addThread(void *aArg)
 {
   AgentTest *test = (AgentTest*) aArg;
-  dlib::sleep(test->m_delay);
+	this_thread::sleep_for(chrono::milliseconds(test->m_delay));
   test->m_adapter->processData("TIME|line|204");
   test->m_out.setstate(ios::eofbit);
 }
@@ -1878,10 +1880,10 @@ void AgentTest::testFailWithDuplicateDeviceUUID()
 void AgentTest::streamThread(void *aArg)
 {
   AgentTest *test = (AgentTest*) aArg;
-  dlib::sleep(test->m_delay);
+	this_thread::sleep_for(chrono::milliseconds(test->m_delay));
   test->m_agent->setSequence(test->m_agent->getSequence() + 20);
   test->m_adapter->processData("TIME|line|204");
-  dlib::sleep(120);
+	this_thread::sleep_for(120ms);
   test->m_out.setstate(ios::eofbit);
 }
 

--- a/test/change_observer_test.cpp
+++ b/test/change_observer_test.cpp
@@ -31,6 +31,8 @@
 // SUCH PARTY HAD ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES.
 //
 #include "change_observer_test.hpp"
+#include <chrono>
+#include <thread>
 #include <dlib/misc_api.h>
 
 // Registers the fixture into the 'registry'
@@ -60,7 +62,7 @@ void ChangeObserverTest::testAddObserver()
 static void signaler(void *aObj)
 {
 	ChangeSignaler *s = (ChangeSignaler *) aObj;
-	dlib::sleep(1000);
+	this_thread::sleep_for(1000ms);
 	s->signalObservers(100);
 }
 
@@ -77,7 +79,7 @@ void ChangeObserverTest::testSignalObserver()
 	CPPUNIT_ASSERT(!obj.wait(500));
 
 	// Wait for things to clean up...
-	dlib::sleep(1000);
+	this_thread::sleep_for(1000ms);
 }
 
 void ChangeObserverTest::testCleanup()
@@ -115,7 +117,7 @@ void ChangeObserverTest::testChangeSequence()
 	CPPUNIT_ASSERT_EQUAL((uint64_t) 100ull, obj.getSequence());
 
 	// Wait for things to clean up...
-	dlib::sleep(1000);
+	this_thread::sleep_for(1000ms);
 }
 
 static void signaler3(void *aObj)
@@ -134,10 +136,10 @@ void ChangeObserverTest::testChangeSequence2()
 	m_signaler->addObserver(&obj);
 	dlib::create_new_thread(signaler3, m_signaler);
 	CPPUNIT_ASSERT(obj.wait(2000));
-	dlib::sleep(500);
+	this_thread::sleep_for(500ms);
 
 	CPPUNIT_ASSERT_EQUAL((uint64_t) 30ull, obj.getSequence());
 
 	// Wait for things to clean up...
-	dlib::sleep(1000);
+	this_thread::sleep_for(1000ms);
 }

--- a/test/connector_test.cpp
+++ b/test/connector_test.cpp
@@ -31,6 +31,8 @@
 // SUCH PARTY HAD ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES.
 //
 #include "connector_test.hpp"
+#include <chrono>
+#include <thread>
 
 // Registers the fixture into the 'registry'
 CPPUNIT_TEST_SUITE_REGISTRATION(ConnectorTest);
@@ -67,7 +69,7 @@ void ConnectorTest::testConnection()
 	start();
 
 	CPPUNIT_ASSERT_EQUAL(0, m_server->accept(m_serverSocket));
-	dlib::sleep(100);
+	this_thread::sleep_for(100ms);
 	CPPUNIT_ASSERT(m_serverSocket.get());
 	CPPUNIT_ASSERT(!m_connector->m_disconnected);
 }
@@ -83,7 +85,7 @@ void ConnectorTest::testDataCapture()
 	string command("Hello Connector\n");
 	CPPUNIT_ASSERT((size_t) m_serverSocket->write(command.c_str(),
 		   command.length()) == command.length());
-	dlib::sleep(1000);
+	this_thread::sleep_for(1000ms);
 
 	// \n is stripped from the posted data.
 	CPPUNIT_ASSERT_EQUAL(command.substr(0, command.length() - 1), m_connector->m_data);
@@ -95,11 +97,11 @@ void ConnectorTest::testDisconnect()
 	start();
 
 	CPPUNIT_ASSERT_EQUAL(0, m_server->accept(m_serverSocket));
-	dlib::sleep(1000);
+	this_thread::sleep_for(1000ms);
 	CPPUNIT_ASSERT(m_serverSocket.get());
 	CPPUNIT_ASSERT(!m_connector->m_disconnected);
 	m_serverSocket.reset();
-	dlib::sleep(1000);
+	this_thread::sleep_for(1000ms);
 	CPPUNIT_ASSERT(m_connector->m_disconnected);
 }
 
@@ -113,7 +115,7 @@ void ConnectorTest::testProtocolCommand()
 
 	const char *cmd = "* Hello Connector\n";
 	CPPUNIT_ASSERT_EQUAL(strlen(cmd), (size_t) m_serverSocket->write(cmd, strlen(cmd)));
-	dlib::sleep(1000);
+	this_thread::sleep_for(1000ms);
 
 	// \n is stripped from the posted data.
 	CPPUNIT_ASSERT(strncmp(cmd, m_connector->m_command.c_str(), strlen(cmd) - 1) == 0);
@@ -136,7 +138,7 @@ void ConnectorTest::testHeartbeat()
 	// Respond to the heartbeat of 1/2 second
 	const char *pong = "* PONG 1000\n";
 	CPPUNIT_ASSERT_EQUAL(strlen(pong), (size_t) m_serverSocket->write(pong, strlen(pong)));
-	dlib::sleep(1000);
+	this_thread::sleep_for(1000ms);
 
 	CPPUNIT_ASSERT(m_connector->heartbeats());
 	CPPUNIT_ASSERT_EQUAL(1000, m_connector->heartbeatFrequency());
@@ -166,7 +168,7 @@ void ConnectorTest::testHeartbeatPong()
 	// Respond to the heartbeat of 1/2 second
 	const char *pong = "* PONG 1000\n";
 	CPPUNIT_ASSERT_EQUAL(strlen(pong), (size_t) m_serverSocket->write(pong, strlen(pong)));
-	dlib::sleep(10);
+	this_thread::sleep_for(10ms);
 
 	CPPUNIT_ASSERT(!m_connector->m_disconnected);
 	}
@@ -175,7 +177,7 @@ void ConnectorTest::testHeartbeatPong()
 void ConnectorTest::testHeartbeatTimeout()
 {
 	testHeartbeat();
-	dlib::sleep(2100);
+	this_thread::sleep_for(2100ms);
 
 	CPPUNIT_ASSERT(m_connector->m_disconnected);
 }
@@ -198,7 +200,7 @@ void ConnectorTest::testLegacyTimeout()
 	CPPUNIT_ASSERT_EQUAL(strlen(cmd), (size_t) m_serverSocket->write(cmd, strlen(cmd)));
 
 	// No pings, but timeout after 5 seconds of silence
-	dlib::sleep(11000);
+	this_thread::sleep_for(11000ms);
 
 	CPPUNIT_ASSERT(m_connector->m_disconnected);
 }
@@ -271,7 +273,7 @@ void ConnectorTest::testIPV6Connection()
 	start();
 
 	CPPUNIT_ASSERT_EQUAL(0, m_server->accept(m_serverSocket));
-	dlib::sleep(100);
+	this_thread::sleep_for(100ms);
 	CPPUNIT_ASSERT(m_serverSocket.get());
 	CPPUNIT_ASSERT(!m_connector->m_disconnected);
 #endif

--- a/test/globals_test.cpp
+++ b/test/globals_test.cpp
@@ -31,11 +31,8 @@
 // SUCH PARTY HAD ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES.
 //
 #include "globals_test.hpp"
-
-#ifdef _WINDOWS
-	#include <windows.h>
-	#define sleep(s) ::Sleep(s * 1000)
-#endif
+#include <chrono>
+#include <thread>
 
 // Registers the fixture into the 'registry'
 CPPUNIT_TEST_SUITE_REGISTRATION(GlobalsTest);
@@ -94,7 +91,7 @@ void GlobalsTest::testTime()
 	string time2 = getCurrentTime(GMT);
 	CPPUNIT_ASSERT_EQUAL(time1, time2);
 
-	sleep(1);
+	std::this_thread::sleep_for(1s);
 	string time3 = getCurrentTime(GMT);
 	CPPUNIT_ASSERT(time1 != time3);
 
@@ -102,7 +99,7 @@ void GlobalsTest::testTime()
 	string time5 = getCurrentTime(GMT);
 	CPPUNIT_ASSERT_EQUAL(time4, time5);
 
-	sleep(1);
+	std::this_thread::sleep_for(1s);
 	string time6 = getCurrentTime(GMT);
 	CPPUNIT_ASSERT(time4 != time6);
 
@@ -110,7 +107,7 @@ void GlobalsTest::testTime()
 	unsigned int time8 = getCurrentTimeInSec();
 	CPPUNIT_ASSERT_EQUAL(time7, time8);
 
-	sleep(2);
+	std::this_thread::sleep_for(2s);
 	unsigned int time9 = getCurrentTimeInSec();
 	CPPUNIT_ASSERT(time7 < time9);
 }


### PR DESCRIPTION
* Use of std::thread::sleep_for instead of dlib::sleep
* Replaced loops with C++11 ':' syntax