### PR TITLE
Bug Fix: Log file sizes above 4GB were not accepted due to integer ov…

### DIFF
--- a/agent/config.cpp
+++ b/agent/config.cpp
@@ -348,7 +348,7 @@ void AgentConfiguration::LoggerHook(
 	const char* message)
 {
 	stringstream out;
-	char buffer[64];
+	char buffer[64] = {0};
 	timestamp(buffer);
 	out << buffer << ": " << l.name << " [" << threadId << "] " << loggerName << ": " << message;
 #ifdef WIN32
@@ -404,7 +404,7 @@ void AgentConfiguration::configureLogger(dlib::config_reader::kernel_1a &reader)
 	{
 		string name("agent.log");
 		auto sched = RollingFileLogger::NEVER;
-		int maxSize = 10 * 1024 * 1024; // 10MB
+		uint64 maxSize = 10ull * 1024ull * 1024ull; // 10MB
 		int maxIndex = 9;
 
 		if (reader.is_block_defined("logger_config"))
@@ -446,13 +446,13 @@ void AgentConfiguration::configureLogger(dlib::config_reader::kernel_1a &reader)
 			{
 				case 'G':
 				case 'g':
-					maxSize *= 1024;
+					maxSize *= 1024ull;
 				case 'M':
 				case 'm':
-					maxSize *= 1024;
+					maxSize *= 1024ull;
 				case 'K':
 				case 'k':
-					maxSize *= 1024;
+					maxSize *= 1024ull;
 				case 'B':
 				case 'b':
 				case '\0':

--- a/agent/rolling_file_logger.cpp
+++ b/agent/rolling_file_logger.cpp
@@ -27,7 +27,7 @@ using namespace std;
 RollingFileLogger::RollingFileLogger(
 	std::string filename,
 	int maxBackupIndex,
-	size_t maxSize,
+	uint64 maxSize,
 	RollingSchedule schedule) :
 	m_name(filename),
 	m_maxBackupIndex(maxBackupIndex),
@@ -100,7 +100,7 @@ void RollingFileLogger::write(const char *message)
 }
 
 
-void RollingFileLogger::rollover(size_t size)
+void RollingFileLogger::rollover(uint64 size)
 {
 	std::lock_guard<std::mutex> lock(m_fileLock);
 

--- a/agent/rolling_file_logger.hpp
+++ b/agent/rolling_file_logger.hpp
@@ -36,18 +36,18 @@ public:
 	RollingFileLogger(
 		std::string filename,
 		int maxBackupIndex = 9,
-		size_t maxSize = 10 * 1024 * 1024,
+		dlib::uint64 maxSize = 10 * 1024 * 1024,
 		RollingSchedule schedule = NEVER);
 
 	~RollingFileLogger();
 
 	void write(const char *message);
 
-	int getMaxSize() const {
+	dlib::uint64 getMaxSize() const {
 		return m_maxSize; }
 
 protected:
-	void rollover(size_t aSize);
+	void rollover(dlib::uint64 size);
 	int getFileAge();
 
 private:
@@ -58,7 +58,7 @@ private:
 	dlib::file m_file;
 
 	int m_maxBackupIndex;
-	size_t m_maxSize;
+	dlib::uint64 m_maxSize;
 	RollingSchedule m_schedule;
 
 	int m_fd;

--- a/test/config_test.cpp
+++ b/test/config_test.cpp
@@ -409,41 +409,45 @@ void ConfigTest::testLogFileRollover()
 
 void ConfigTest::testMaxSize()
 {
-	istringstream logger("logger_config {"
-			 "max_size = 150\n"
-			 "}\n");
+	istringstream logger(
+		"logger_config {"
+		"max_size = 150\n"
+		"}\n");
 	m_config->loadConfig(logger);
-	RollingFileLogger *fl = m_config->getLogger();
-	CPPUNIT_ASSERT_EQUAL(150, fl->getMaxSize());
+	auto fl = m_config->getLogger();
+	CPPUNIT_ASSERT_EQUAL(150ull, fl->getMaxSize());
 	delete m_config;
 
 	m_config = new AgentConfiguration();
-	istringstream logger2("logger_config {"
-			  "max_size = 15K\n"
-			  "}\n");
+	istringstream logger2(
+		"logger_config {"
+		"max_size = 15K\n"
+		"}\n");
 	m_config->loadConfig(logger2);
 
 	fl = m_config->getLogger();
-	CPPUNIT_ASSERT_EQUAL(15 * 1024, fl->getMaxSize());
+	CPPUNIT_ASSERT_EQUAL(15ull * 1024ull, fl->getMaxSize());
 	delete m_config;
 
 	m_config = new AgentConfiguration();
-	istringstream logger3("logger_config {"
-			  "max_size = 15M\n"
-			  "}\n");
+	istringstream logger3(
+		"logger_config {"
+		"max_size = 15M\n"
+		"}\n");
 	m_config->loadConfig(logger3);
 
 	fl = m_config->getLogger();
-	CPPUNIT_ASSERT_EQUAL(15 * 1024 * 1024, fl->getMaxSize());
+	CPPUNIT_ASSERT_EQUAL(15ull * 1024ull * 1024ull, fl->getMaxSize());
 	delete m_config;
 
 	m_config = new AgentConfiguration();
-	istringstream logger4("logger_config {"
-			  "max_size = 15G\n"
-			  "}\n");
+	istringstream logger4(
+		"logger_config {"
+		"max_size = 15G\n"
+		"}\n");
 	m_config->loadConfig(logger4);
 
 	fl = m_config->getLogger();
-	CPPUNIT_ASSERT_EQUAL(15 * 1024 * 1024 * 1024, fl->getMaxSize());
+	CPPUNIT_ASSERT_EQUAL(15ull * 1024ull * 1024ull * 1024ull, fl->getMaxSize());
 
 }


### PR DESCRIPTION
…erflow on 32-bit platforms

* The log file size was being held in a size_t (32-bit width). This has a maximum size of 2^32 (4GB)
* Modified to use a 64-bit unsigned integer for file size