### PR TITLE
Added option to escape pipes in values of events and samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,6 +744,10 @@ A simple set of events and samples will look something like this:
 
 For simple events and samples, the data is pipe delimited key value pairs with multiple pairs on one line. Each line must have at least one key/value on it or else it has no meaning. The agent will discard any lines where the data is malformed. The end must end with a LF (ASCII 10) or CR-LF (ASCII 15 followed by ASCII 10) (UNIX or Windows conventions respectively). The key will map to the data item using the following items: the `id` attribute, the `name` attribute, and the `CDATA` of the `Source` element. If the key does not match it will be rejected and the agent will log the first time it fails.  
 
+If the value itself contains a pipe character `|` the pipe must be escaped using a leading backslash `\`. In addition the entire value has to be wrapped in quotes:
+
+        2009-06-15T00:00:00.000000|description|"Text with \| (pipe) character."
+
 Conditions are a little more complex since there are multiple fields and must appear on one line. The fields are as follows:
 
 	<timestamp>|<data_item_name>|<level>|<native_code>|<native_severity>|<qualifier>|<message>

--- a/agent/adapter.hpp
+++ b/agent/adapter.hpp
@@ -80,6 +80,7 @@ public:
   /* For testing... */
   void setBaseOffset(uint64_t aOffset) { mBaseOffset = aOffset; }
   void setBaseTime(uint64_t aOffset) { mBaseTime = aOffset; }
+  static void getEscapedLine(std::istringstream &stream, std::string &store);
   
   /* Inherited method to incoming data from the server */
   virtual void processData(const std::string& data);

--- a/test/adapter_test.cpp
+++ b/test/adapter_test.cpp
@@ -33,6 +33,13 @@
 
 #include "adapter_test.hpp"
 
+#include "adapter.hpp"
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+
 // Registers the fixture into the 'registry'
 CPPUNIT_TEST_SUITE_REGISTRATION(AdapterTest);
 
@@ -52,4 +59,65 @@ void AdapterTest::testAdapter()
 {
 }
 
+void AdapterTest::testEscapedLine()
+{
+  std::map<std::string, std::vector<std::string> > data;
+  // correctly escaped
+  data["\"a\\|b\""] = {"a|b"};
+  data["\"a\\|b\"|z"] = {"a|b", "z"};
+  data["y|\"a\\|b\""] = {"y", "a|b"};
+  data["y|\"a\\|b\"|z"] = {"y", "a|b", "z"};
 
+  // correctly escaped with multiple pipes
+  data["\"a\\|b\\|c\""] = {"a|b|c"};
+  data["\"a\\|b\\|c\"|z"] = {"a|b|c", "z"};
+  data["y|\"a\\|b\\|c\""] = {"y", "a|b|c"};
+  data["y|\"a\\|b\\|c\"|z"] = {"y", "a|b|c", "z"};
+
+  // correctly escaped with pipe at front
+  data["\"\\|b\\|c\""] = {"|b|c"};
+  data["\"\\|b\\|c\"|z"] = {"|b|c", "z"};
+  data["y|\"\\|b\\|c\""] = {"y", "|b|c"};
+  data["y|\"\\|b\\|c\"|z"] = {"y", "|b|c", "z"};
+
+  // correctly escaped with pipes at end
+  data["\"a\\|b\\|\""] = {"a|b|"};
+  data["\"a\\|b\\|\"|z"] = {"a|b|", "z"};
+  data["y|\"a\\|b\\|\""] = {"y", "a|b|"};
+  data["y|\"a\\|b\\|\"|z"] = {"y", "a|b|", "z"};
+
+  // missing first quote
+  data["a\\|b\""] = {"a\\", "b\""};
+  data["a\\|b\"|z"] = {"a\\", "b\"", "z"};
+  data["y|a\\|b\""] = {"y", "a\\", "b\""};
+  data["y|a\\|b\"|z"] = {"y", "a\\", "b\"", "z"};
+
+  // missing first quote and multiple pipes
+  data["a\\|b\\|c\""] = {"a\\", "b\\", "c\""};
+  data["a\\|b\\|c\"|z"] = {"a\\", "b\\", "c\"", "z"};
+  data["y|a\\|b\\|c\""] = {"y", "a\\", "b\\", "c\""};
+  data["y|a\\|b\\|c\"|z"] = {"y", "a\\", "b\\", "c\"", "z"};
+
+  // missing last quote
+  data["\"a\\|b"] = {"\"a\\", "b"};
+  data["\"a\\|b|z"] = {"\"a\\", "b", "z"};
+  data["y|\"a\\|b"] = {"y", "\"a\\", "b"};
+  data["y|\"a\\|b|z"] = {"y", "\"a\\", "b", "z"};
+
+  // missing last quote and pipe at end et al.
+  data["\"a\\|"] = {"\"a\\", ""};
+  data["y|\"a\\|"] = {"y", "\"a\\", ""};
+  data["y|\"a\\|z"] = {"y", "\"a\\", "z"};
+  data["y|\"a\\|\"z"] = {"y", "\"a\\", "\"z"};
+
+  for (auto it = data.begin(); it != data.end(); ++it)
+  {
+    std::string value;
+    std::istringstream toParse(it->first);
+    for (const std::string &expected : it->second)
+    {
+      Adapter::getEscapedLine(toParse, value);
+      CPPUNIT_ASSERT_EQUAL_MESSAGE("Source  : " + it->first, expected, value);
+    }
+  }
+}

--- a/test/adapter_test.hpp
+++ b/test/adapter_test.hpp
@@ -50,6 +50,7 @@ class AdapterTest : public CppUnit::TestFixture
 {
   CPPUNIT_TEST_SUITE(AdapterTest);
   CPPUNIT_TEST(testAdapter);
+  CPPUNIT_TEST(testEscapedLine);
   CPPUNIT_TEST_SUITE_END();
   
 public:
@@ -60,6 +61,7 @@ protected:
   
 protected:
   void testAdapter();
+  void testEscapedLine();
 };
 
 #endif


### PR DESCRIPTION
This pull request tries to overcome the limitation that values streamed from the adapter to the agent can not contain a pipe character on its own because the pipe is used as a protocol special character. See also issue #38.

For now only values and events are considered.