### PR TITLE
argc should be non-negative

### DIFF
--- a/agent/service.cpp
+++ b/agent/service.cpp
@@ -724,7 +724,7 @@ int MTConnectService::main(int argc, const char *argv[])
       initialize(argc - 2, argv + 2);
     }
   } else {
-    initialize(argc - 2, argv + 2);
+    initialize(0, argv);
   }
   
   start();


### PR DESCRIPTION
`argc` holds the element count of `argv` and thus can't be negative (see also [cppreference](https://en.cppreference.com/w/cpp/language/main_function)). Even if OptionsList::parse() uses `while (aArgc > 0)` do not set `argc` to a negative number.