### PR TITLE
Let "agent config_file" be a shorthand for "agent run config_file"

### DIFF
--- a/agent/service.cpp
+++ b/agent/service.cpp
@@ -720,8 +720,11 @@ int MTConnectService::main(int argc, const char *argv[])
     } else if (strcasecmp( argv[1], "debug") == 0) {
       mIsDebug = true;
       initialize(argc - 2, argv + 2);
-    } else {
+    } else if (strcasecmp(argv[1], "run") == 0) {
       initialize(argc - 2, argv + 2);
+    } else {
+      // Started without [help|daemonize|debug|run] thus assume argv[1] is the config file.
+      initialize(argc - 1, argv + 1);
     }
   } else {
     initialize(argc - 2, argv + 2);


### PR DESCRIPTION
If one calls "agent config_file" the agent ignores the passed config file. Instead it tries to use agent.cfg of the current directory. If that also fails you see

    Usage: agent  [<file>]
        <file>               : The configuration file

on the command line... 😧

This commit passes the user defined config file to the normal procedure.