### PR TITLE
Add option for paths in a config file relative to config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,6 +603,10 @@ Configuration Parameters
 
     *Default*: 15
 
+* `PathRelativeToConfigFile` - If set to true, relative paths in the configuration item `Device` and `Path` are resolved relative to the current configuration file.
+
+    *Default*: false
+
 
 ### Adapter configuration items ###
 

--- a/agent/agent.hpp
+++ b/agent/agent.hpp
@@ -189,6 +189,9 @@ public:
   
   // Update DOM when key changes
   void updateDom(Device *aDevice);
+
+  // Exposed for unit tests
+  bool isFile(const std::string& aUri) { return mFileMap.count(aUri) > 0; }
   
 protected:
   /* HTTP methods to handle the 3 basic calls */
@@ -251,8 +254,6 @@ protected:
   /* Get a file */
   std::string handleFile(const std::string& aUri, outgoing_things& aOutgoing);
 
-  bool isFile(const std::string& aUri) { return mFileMap.count(aUri) > 0; }
-  
   /* Perform a check on parameter and return a value or a code */
   int checkAndGetParam(
     const key_value_map& queries,

--- a/agent/config.hpp
+++ b/agent/config.hpp
@@ -24,7 +24,8 @@ public:
   virtual void initialize(int aArgc, const char *aArgv[]);
 
   void configureLogger(dlib::config_reader::kernel_1a &aReader);
-  void loadConfig(std::istream &aFile);
+  void loadConfig(const std::string& aConfigFile);
+  void loadConfig(std::istream &aFile, const std::string& aConfigFileFolder = std::string());
 
   void setAgent(Agent *aAgent) { mAgent = aAgent; }
   Agent *getAgent() { return mAgent; }
@@ -37,11 +38,12 @@ protected:
                     int aLegacyTimeout, int aReconnectInterval, bool aIgnoreTimestamps,
                     bool aConversionRequired, bool aUpcaseValue);
   void loadAllowPut(dlib::config_reader::kernel_1a &aReader);
-  void loadNamespace(dlib::config_reader::kernel_1a &aReader, 
-                     const char *aNamespaceType, 
-                     NamespaceFunction *aCallback);
-  void loadFiles(dlib::config_reader::kernel_1a &aReader);
-  void loadStyle(dlib::config_reader::kernel_1a &aReader, const char *aDoc, StyleFunction *aFunction);
+  void loadNamespace(dlib::config_reader::kernel_1a &aReader,
+                     const char *aNamespaceType,
+                     NamespaceFunction *aCallback,
+                     const std::string& aRelativePathBase);
+  void loadFiles(dlib::config_reader::kernel_1a &aReader, const std::string& aRelativePathBase);
+  void loadStyle(dlib::config_reader::kernel_1a &aReader, const char *aDoc, StyleFunction *aFunction, const std::string& aRelativePathBase);
   void loadTypes(dlib::config_reader::kernel_1a &aReader);
   
   void LoggerHook(const std::string& aLoggerName,

--- a/test/config_test.cpp
+++ b/test/config_test.cpp
@@ -446,3 +446,27 @@ void ConfigTest::testMaxSize()
   CPPUNIT_ASSERT_EQUAL(15 * 1024 * 1024 * 1024, fl->getMaxSize());
 
 }
+
+void ConfigTest::testConfigFileRelativePaths()
+{
+  dlib::file config(CPPUNIT_SOURCELINE().fileName() + "/../data/relative_path_to_config/agent.cfg");
+  mConfig->loadConfig(config.full_name());
+
+  Agent *agent = mConfig->getAgent();
+  CPPUNIT_ASSERT(agent);
+  const std::vector<Device *> devices = agent->getDevices();
+  CPPUNIT_ASSERT(devices.size() > 0);
+  Device *device = agent->getDevices()[0];
+
+  // Test config "Devices"
+  CPPUNIT_ASSERT_EQUAL(std::string("LinuxCNC"), device->getName());
+
+  // Test config "Files -> Path"
+  CPPUNIT_ASSERT(agent->isFile("/files/Readme.md"));
+
+  // Test config "fooNamespaces -> Path", here StreamsNamespaces
+  CPPUNIT_ASSERT(agent->isFile("/schemas/MTConnectStreams_1.4.xsd"));
+
+  // Test config "fooStyle -> Path", here StreamsStyle
+  CPPUNIT_ASSERT(agent->isFile("/styles/Streams.xsl"));
+}

--- a/test/config_test.hpp
+++ b/test/config_test.hpp
@@ -63,6 +63,7 @@ class ConfigTest : public CppUnit::TestFixture
   CPPUNIT_TEST(testSchemaDirectory);
   CPPUNIT_TEST(testLogFileRollover);
   CPPUNIT_TEST(testMaxSize);
+  CPPUNIT_TEST(testConfigFileRelativePaths);
   CPPUNIT_TEST_SUITE_END();
   
 public:
@@ -91,6 +92,7 @@ protected:
   void testSchemaDirectory();
   void testLogFileRollover();
   void testMaxSize();
+  void testConfigFileRelativePaths();
 };
 
 #endif

--- a/test/data/relative_path_to_config/agent.cfg
+++ b/test/data/relative_path_to_config/agent.cfg
@@ -1,0 +1,21 @@
+PathRelativeToConfigFile = true
+Devices = ../../../samples/test_config.xml
+
+Files {
+  myfile {
+    Location = /files/Readme.md
+    Path = ../../../Readme.md
+  }
+}
+
+StreamsNamespaces {
+  m {
+    Location = /schemas/MTConnectStreams_1.4.xsd
+    Path = ../../../schemas/MTConnectStreams_1.4.xsd
+  }
+}
+
+StreamsStyle {
+  Location = /styles/Streams.xsl
+  Path = ../../../styles/Streams.xsl
+}


### PR DESCRIPTION
Currently relative paths in the configuration file are resolved using the current directory or the one of the executable. When creating a "package" for machine deployment, however, containing the config file and all sorts of styles etc. one can't know where it is installed, where the actual executable is and from where the agent is started.

With the new option you can ship the config file with all other files and have proper path right from the beginning. The agent must only use the deployed config file, regardless where the agent is installed and from which folder it is started.

(Currently I do not have a Windows machine at hand, so that part is coded at best knowledge...)