### PR TITLE
Fix UB for short strings

### DIFF
--- a/agent/config.cpp
+++ b/agent/config.cpp
@@ -518,7 +518,7 @@ void AgentConfiguration::loadConfig(std::istream &aFile)
   if (reader.is_key_defined("Devices")) {
     string fileName = reader["Devices"];
     devices_files.push_back(fileName);
-    if (!mExePath.empty() && fileName[0] != '/' && fileName[0] != '\\' && fileName[1] != ':')
+    if (!mExePath.empty() && !fileName.empty() && fileName[0] != '/' && fileName[0] != '\\' && (fileName.size() < 2 || fileName[1] != ':'))
       devices_files.push_back(mExePath + reader["Devices"]);
   }
   

--- a/agent/service.cpp
+++ b/agent/service.cpp
@@ -311,7 +311,7 @@ void MTConnectService::install()
   RegCloseKey(mtc);
 
   // Fully qualify the configuration file name.
-  if (mConfigFile[0] != '/' && mConfigFile[0] != '\\' && mConfigFile[1] != ':')
+  if (!mConfigFile.empty() && mConfigFile[0] != '/' && mConfigFile[0] != '\\' && (mConfigFile.size() < 2 || mConfigFile[1] != ':'))
   {
     // Relative file name
     char path[MAX_PATH];


### PR DESCRIPTION
Admittedly it's unlikely that one uses a single character for a device/config file. However, it strengthen the code and avoids undefined behavior.