### PR TITLE
Add missing endl to debug message

### DIFF
--- a/agent/config.cpp
+++ b/agent/config.cpp
@@ -114,7 +114,7 @@ AgentConfiguration::AgentConfiguration() :
       mExePath.erase(found + 1);
     }
     
-    cout << "Configuration search path: current directory and " << mExePath;
+    cout << "Configuration search path: current directory and " << mExePath << endl;
   } else {
     mExePath = "";
   }


### PR DESCRIPTION
The missing endl is annoying because it makes parsing the agent version from cout complicated. Turns

    Configuration search path: current directory and /Volumes/Foo/MTConnect Agent Version 1.4.0.12 - built on Sun Oct 20 17:39:45 2019

to

    Configuration search path: current directory and /Volumes/Foo/
    MTConnect Agent Version 1.4.0.12 - built on Sun Oct 20 17:39:45 2019