### PR TITLE
Add Travis CI build file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,51 @@
+language: cpp
+os: linux
+dist: trusty
+sudo: false
+
+branches:
+  only:
+    - master
+
+cache:
+  apt: true
+
+addons:
+  apt:
+    packages: [libcppunit-dev, libxml2-dev]
+
+git:
+  submodules: false
+
+before_install:
+  - git submodule update --init --remote -- schemas
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update         ; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install cppunit; fi
+
+matrix:
+  include:
+    - os: linux
+      dist: bionic
+      compiler: gcc
+
+    - os: linux
+      dist: bionic
+      compiler: clang
+
+    - os: linux
+      dist: xenial
+      compiler: gcc
+
+    - os: linux
+      dist: xenial
+      compiler: clang
+
+    - os: osx
+      osx_image: xcode11.2
+      compiler: clang
+
+script:
+  - mkdir build
+  - cd build
+  - cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=ON ..
+  - cmake --build . --target all


### PR DESCRIPTION
Add .travis.yml file for automated building to spot coding errors early. For a first step only release building on the newest Linux and OSX versions are checked. Later it can be extended with unit tests and so on.

What puzzles me is that for Linux c++11 is enabled. What are the compiler requirements for the master? I thought it is c++98 standard?

If the pull request is accepted, someone with admin rights on the cppagent repository must sign-in to [https://travis-ci.com](https://travis-ci.com/) and activate the build script. Then all further commits to master would be automatically checked and the success would be indicated in the commit log. (For example see https://github.com/lorenzhaas/cppagent/commits/master, red cross and green check mark.)

(Sorry for the mess with the first pull request for the Travis integration. I could also not reopen it in order to reuse, because I force pushed before reopening... sigh.)