### PR TITLE
Added note about newlines in PING/PONG section

### DIFF
--- a/README.md
+++ b/README.md
@@ -953,6 +953,8 @@ Adapter:
 	* PONG 10000
 
 This indicates that the adapter is expecting a `PING` every 10 seconds and if there is no `PING`, in 2x the frequency, then the adapter should close the connection. At the same time, if the agent does not receive a `PONG` within 2x frequency, then it will close the connection. If no `PONG` response is received, the agent assumes the adapter is incapable of participating in heartbeat protocol and uses the legacy time specified above.
+	
+Just as with the SHDR protocol, these messages must end with an LF (ASCII 10) or CR-LF (ASCII 15 followed by ASCII 10).
 
 HTTP PUT/POST Method of Uploading Data
 -----


### PR DESCRIPTION
I have set up multiple adapters based on the information in this readme, and multiple times I have gone down a long road of trying to understand why the Agent isn't receiving my pongs, only to discover its because I didn't provide a newline at the end. So I think it might be good to add this little note to that section so its more clear.