### PR TITLE
233 logging level not working

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 set(AGENT_VERSION_MAJOR 2)
 set(AGENT_VERSION_MINOR 0)
 set(AGENT_VERSION_PATCH 0)
-set(AGENT_VERSION_BUILD 7)
+set(AGENT_VERSION_BUILD 8)
 set(AGENT_VERSION_RC "")
 
 # This minimum version is to support Visual Studio 2017 and C++ feature checking and FetchContent

--- a/conanfile.py
+++ b/conanfile.py
@@ -27,6 +27,7 @@ class CppAgentConan(ConanFile):
         "boost:shared": False,
         "boost:without_python": True,
         "boost:without_test": True,
+        "boost:extra_b2_flags": "visibility=hidden",
 
         "libxml2:shared": False,
         "libxml2:include_utils": False,

--- a/src/agent.cpp
+++ b/src/agent.cpp
@@ -64,8 +64,8 @@ namespace mtconnect {
       m_strand(m_context),
       m_xmlParser(make_unique<parser::XmlParser>()),
       m_version(
-          GetOption<string>(options, mtconnect::configuration::SchemaVersion).
-                value_or(to_string(AGENT_VERSION_MAJOR) + "." + to_string(AGENT_VERSION_MINOR))),
+          GetOption<string>(options, mtconnect::configuration::SchemaVersion)
+              .value_or(to_string(AGENT_VERSION_MAJOR) + "." + to_string(AGENT_VERSION_MINOR))),
       m_configXmlPath(configXmlPath),
       m_pretty(GetOption<bool>(options, mtconnect::configuration::Pretty).value_or(false))
   {

--- a/src/configuration/agent_config.cpp
+++ b/src/configuration/agent_config.cpp
@@ -451,10 +451,12 @@ namespace mtconnect::configuration {
                          {"file_name", defaultFileName},
                          {"archive_pattern", defaultArchivePattern},
                          {"level", "info"s}});
-    AddOptions(logger, options, {{"output", string()}});
+    AddOptions(logger, options, {{"output", string()},
+                                 {"logging_level", string()}});
 
     auto output = GetOption<string>(options, "output");
-    auto level = setLoggingLevel(*GetOption<string>(options, "level"));
+    auto levelOpt = *GetOption<string>(options, "level");
+    auto level = setLoggingLevel(GetOption<string>(options, "logging_level").value_or(levelOpt));
 
     gAgentLogger = m_logger = &::boost::log::trivial::logger::get();
 

--- a/src/configuration/agent_config.cpp
+++ b/src/configuration/agent_config.cpp
@@ -449,14 +449,14 @@ namespace mtconnect::configuration {
                          {"rotation_size", "2mb"s},
                          {"max_index", 9},
                          {"file_name", defaultFileName},
-                         {"archive_pattern", defaultArchivePattern},
-                         {"level", "info"s}});
-    AddOptions(logger, options, {{"output", string()},
-                                 {"logging_level", string()}});
+                         {"archive_pattern", defaultArchivePattern}});
+    AddOptions(logger, options,
+               {{"output", string()}, {"level", string()}, {"logging_level", string()}});
 
     auto output = GetOption<string>(options, "output");
-    auto levelOpt = *GetOption<string>(options, "level");
-    auto level = setLoggingLevel(GetOption<string>(options, "logging_level").value_or(levelOpt));
+    auto level = setLoggingLevel(
+        GetOption<string>(options, "level")
+            .value_or(GetOption<string>(options, "logging_level").value_or("info"s)));
 
     gAgentLogger = m_logger = &::boost::log::trivial::logger::get();
 

--- a/test/agent_device_test.cpp
+++ b/test/agent_device_test.cpp
@@ -178,7 +178,7 @@ TEST_F(AgentDeviceTest, AdapterAddedProbeTest)
     PARSE_XML_RESPONSE("/Agent/probe");
     auto version = to_string(AGENT_VERSION_MAJOR) + "." + to_string(AGENT_VERSION_MINOR);
     ASSERT_XML_PATH_EQUAL(doc, AGENT_PATH "@mtconnectVersion", version.c_str());
-    
+
     ASSERT_XML_PATH_COUNT(doc, ADAPTERS_PATH "/*", 1);
     ASSERT_XML_PATH_EQUAL(doc, ADAPTER_PATH "@id", ID_PREFIX);
     ASSERT_XML_PATH_EQUAL(doc, ADAPTER_PATH "@name", "127.0.0.1:21788");

--- a/test/config_test.cpp
+++ b/test/config_test.cpp
@@ -974,4 +974,41 @@ logger_config {
     EXPECT_EQ(severity_level::fatal, m_config->getLogLevel());
   }
 
+  TEST_F(ConfigTest, log_should_support_logging_level)
+  {
+    chdir(TEST_BIN_ROOT_DIR);
+    m_config->updateWorkingDirectory();
+    m_config->setDebug(false);
+
+    using namespace boost::log::trivial;
+
+    string str(R"(
+logger_config {
+   logging_level = fatal
+}
+)");
+
+    m_config->loadConfig(str);
+    EXPECT_EQ(severity_level::fatal, m_config->getLogLevel());
+  }
+
+  TEST_F(ConfigTest, log_level_should_override_logging_level)
+  {
+    chdir(TEST_BIN_ROOT_DIR);
+    m_config->updateWorkingDirectory();
+    m_config->setDebug(false);
+
+    using namespace boost::log::trivial;
+
+    string str(R"(
+logger_config {
+   level = warning
+   logging_level = fatal
+}
+)");
+
+    m_config->loadConfig(str);
+    EXPECT_EQ(severity_level::warning, m_config->getLogLevel());
+  }
+
 }  // namespace

--- a/test/observation_test.cpp
+++ b/test/observation_test.cpp
@@ -231,26 +231,22 @@ TEST_F(ObservationTest, subType_prefix_should_be_passed_through)
 TEST_F(ObservationTest, shoud_handle_asset_type)
 {
   ErrorList errors;
-  auto dataItem = DataItem::make(
-      {{"id", "c1"s}, {"category", "EVENT"s}, {"type", "ASSET_CHANGED"s}},
-      errors);
+  auto dataItem =
+      DataItem::make({{"id", "c1"s}, {"category", "EVENT"s}, {"type", "ASSET_CHANGED"s}}, errors);
 
   auto event1 = Observation::make(dataItem, {{"VALUE", "123"s}, {"assetType", "CuttingTool"s}},
-                                 m_time, errors);
+                                  m_time, errors);
   ASSERT_EQ(0, errors.size());
-  
+
   ASSERT_EQ("CuttingTool"s, event1->get<string>("assetType"));
   ASSERT_EQ("123"s, event1->getValue<string>());
 
-
-  auto event2 = Observation::make(dataItem, {{"VALUE", "UNAVAILABLE"s}},
-                                 m_time, errors);
+  auto event2 = Observation::make(dataItem, {{"VALUE", "UNAVAILABLE"s}}, m_time, errors);
   ASSERT_EQ(0, errors.size());
-  
+
   ASSERT_TRUE(event2->isUnavailable());
   ASSERT_EQ("UNAVAILABLE"s, event2->get<string>("assetType"));
 }
-
 
 // TODO: Make sure these tests are covered someplace else. Refactoring
 //       Moved this functionality outside the observation.


### PR DESCRIPTION
Added `logging_level` as log configuration option. `level` also supported.