### PR TITLE
Workflow update

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -38,7 +38,8 @@ jobs:
       # see https://github.com/actions/checkout
       - uses: actions/checkout@v3
         with:
-          ref: v${{ env.VERSION }}
+          # ref: v${{ env.VERSION }}
+          ref: master
 
       # the QEMU emulator lets us build for arm processors also
       # see https://github.com/docker/setup-qemu-action

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -11,7 +11,7 @@
 name: Build Docker image
 
 env:
-  VERSION: 2.0.0.7
+  VERSION: 2.0.0.8
   PLATFORMS: linux/amd64,linux/arm64
 
 # when to run workflow

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -38,8 +38,8 @@ jobs:
       # see https://github.com/actions/checkout
       - uses: actions/checkout@v3
         with:
-          # ref: v${{ env.VERSION }}
-          ref: master
+          ref: v${{ env.VERSION }}
+          # ref: master
 
       # the QEMU emulator lets us build for arm processors also
       # see https://github.com/docker/setup-qemu-action

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,5 +1,10 @@
 # build docker image and push to docker hub
 
+# note: this won't work because the cross-platform build takes around 10h,
+# but github limits us to 6h.
+# so need to build it locally and push to docker hub.
+# see Dockerfile for instructions.
+
 # needs github secrets set for -
 #   DOCKERHUB_USERNAME - ie mtconnect
 #   DOCKERHUB_TOKEN - token for that account


### PR DESCRIPTION
I tried building the cross-platform image using this github workflow, but it failed after it reached the 6h limit.

So this file serves as a warning - it has a comment that it doesn't work. You can delete it if you'd prefer. 

I built the image today on an amd64 comp though - it took around 10 hours. It's the arm (sub-)image that takes so long - the amd part only takes 30mins or so. 

So I pushed the image up to our Docker hub for now - https://hub.docker.com/repository/docker/ladder99/agent 
