### PR TITLE
237 need to automatically add asset count for a device and update the data set

### DIFF
--- a/src/agent.cpp
+++ b/src/agent.cpp
@@ -238,6 +238,15 @@ namespace mtconnect {
       {
         m_loopback->receive(di, {{"assetType", asset->getName()}, {"VALUE", asset->getAssetId()}});
       }
+      
+      auto dc = device->getAssetCount();
+      if (dc)
+      {
+        auto count = m_assetStorage->getCountForType(asset->getType());
+        
+        DataSet set{DataSetEntry(asset->getType(), int64_t(count))};
+        m_loopback->receive(dc, {{"VALUE", set}});
+      }
     }
   }
 

--- a/src/agent.cpp
+++ b/src/agent.cpp
@@ -419,6 +419,17 @@ namespace mtconnect {
                                errors);
       device->addDataItem(di, errors);
     }
+    
+    if (!device->getAssetCount() && (major >= 2))
+    {
+      entity::ErrorList errors;
+      auto di = DataItem::make({{"type", "ASSET_COUNT"s},
+                                {"id", device->getId() + "_asset_count"},
+                                {"category", "EVENT"s},
+                                {"representation", "DATA_SET"s}},
+                               errors);
+      device->addDataItem(di, errors);
+    }
   }
 
   void Agent::initializeDataItems(DevicePtr device)
@@ -878,7 +889,7 @@ namespace mtconnect {
     }
     else if (cmd == "RemoveAll")
     {
-      string type = command->get<string>("type");
+      auto type = command->maybeGet<string>("type");
       auto device = command->maybeGet<string>("device");
       asset::AssetList list;
       m_agent->removeAllAssets(device, type, nullopt, list);

--- a/src/device_model/device.cpp
+++ b/src/device_model/device.cpp
@@ -116,6 +116,8 @@ namespace mtconnect {
         m_assetChanged = dataItem;
       else if (dataItem->getType() == "ASSET_REMOVED")
         m_assetRemoved = dataItem;
+      else if (dataItem->getType() == "ASSET_COUNT")
+        m_assetCount = dataItem;
     }
 
     DataItemPtr Device::getDeviceDataItem(const std::string &name) const

--- a/src/device_model/device.hpp
+++ b/src/device_model/device.hpp
@@ -83,6 +83,7 @@ namespace mtconnect {
       DataItemPtr getAvailability() const { return m_availability; }
       DataItemPtr getAssetChanged() const { return m_assetChanged; }
       DataItemPtr getAssetRemoved() const { return m_assetRemoved; }
+      DataItemPtr getAssetCount() const { return m_assetCount; }
 
       void setPreserveUuid(bool v) { m_preserveUuid = v; }
       bool preserveUuid() const { return m_preserveUuid; }
@@ -99,6 +100,7 @@ namespace mtconnect {
       DataItemPtr m_availability;
       DataItemPtr m_assetChanged;
       DataItemPtr m_assetRemoved;
+      DataItemPtr m_assetCount;
 
       // Mapping of device names to data items
       std::unordered_map<std::string, std::weak_ptr<data_item::DataItem>> m_deviceDataItemsByName;

--- a/src/printer/xml_printer.cpp
+++ b/src/printer/xml_printer.cpp
@@ -620,7 +620,7 @@ namespace mtconnect::printer {
         mtcLocation = xmlns + " " + ns.second.mSchemaLocation;
       }
     }
-
+    
     // Write the schema location
     if (location.empty() && !mtcLocation.empty())
       location = mtcLocation;
@@ -650,8 +650,13 @@ namespace mtconnect::printer {
     sprintf(version, "%d.%d.%d.%d", AGENT_VERSION_MAJOR, AGENT_VERSION_MINOR, AGENT_VERSION_PATCH,
             AGENT_VERSION_BUILD);
     addAttribute(writer, "version", version);
+    
+    int major, minor;
+    char c;
+    stringstream v(m_schemaVersion);
+    v >> major >> c >> minor;
 
-    if (m_schemaVersion >= "1.7")
+    if (major > 1 || (major == 1 && minor >= 7))
     {
       addAttribute(writer, "deviceModelChangeTime", m_modelChangeTime);
     }
@@ -675,7 +680,7 @@ namespace mtconnect::printer {
       addAttribute(writer, "lastSequence", to_string(lastSeq));
     }
 
-    if (aType == eDEVICES && count && !count->empty())
+    if (major < 2 && aType == eDEVICES && count && !count->empty())
     {
       AutoElement ele(writer, "AssetCounts");
 

--- a/test/agent_test.cpp
+++ b/test/agent_test.cpp
@@ -2260,6 +2260,21 @@ TEST_F(AgentTest, AssetAdditionOfAssetRemoved15)
   }
 }
 
+TEST_F(AgentTest, shound_add_asset_count_when_20)
+{
+  m_agentTestHelper->createAgent("/samples/min_config.xml", 8, 4, "2.0", 25);
+
+  {
+    PARSE_XML_RESPONSE("/LinuxCNC/probe");
+    ASSERT_XML_PATH_COUNT(doc, "//m:DataItem[@type='ASSET_CHANGED']", 1);
+    ASSERT_XML_PATH_EQUAL(doc, "//m:DataItem[@type='ASSET_CHANGED']@discrete", "true");
+    ASSERT_XML_PATH_COUNT(doc, "//m:DataItem[@type='ASSET_REMOVED']", 1);
+    ASSERT_XML_PATH_COUNT(doc, "//m:DataItem[@type='ASSET_COUNT']", 1);
+    ASSERT_XML_PATH_EQUAL(doc, "//m:DataItem[@type='ASSET_COUNT']@representation", "DATA_SET");
+  }
+}
+
+
 TEST_F(AgentTest, AssetPrependId)
 {
   addAdapter();
@@ -2676,4 +2691,9 @@ TEST_F(AgentTest, put_condition_should_parse_condition_data)
     ASSERT_XML_PATH_EQUAL(doc, "//m:Fault@nativeSeverity", "1");
     ASSERT_XML_PATH_EQUAL(doc, "//m:Fault", "SCANHISTORYRESET");
   }
+}
+
+TEST_F(AgentTest, asset_count_should_not_occur_in_header_post_20)
+{
+  GTEST_SKIP();
 }

--- a/test/test_utilities.cpp
+++ b/test/test_utilities.cpp
@@ -23,6 +23,7 @@
 
 #include <libxml/tree.h>
 #include <libxml/xpathInternals.h>
+#include <libxml/xmlwriter.h>
 
 #include "test_utilities.hpp"
 
@@ -127,11 +128,17 @@ void xpathTest(xmlDocPtr doc, const char *xpath, const char *expected, const std
 
   if (!obj || !obj->nodesetval || obj->nodesetval->nodeNr == 0)
   {
+    int size;
+    xmlChar *memory;
+    xmlDocDumpFormatMemory(doc, &memory, &size, 1);
+    
     stringstream message;
     message << file << "(" << line << "): "
-            << "Xpath " << xpath << " did not match any nodes in XML document";
+      << "Xpath " << xpath << " did not match any nodes in XML document" << endl << ((const char *) memory);
+    xmlFree(memory);
+    
     FAIL() << message.str();
-
+    
     if (obj)
       xmlXPathFreeObject(obj);
 


### PR DESCRIPTION
Added support for the new 2.0 AssetCount data item.

Removes AssetCount in the header when version > 2.0 and adds the data item at the device level.

Modifies the dataset whenever a new asset is added or removed.