### PR TITLE
Begin integrating GitHub releases into workflow and integrated tests into build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,9 @@ jobs:
 
     - name: Install Conan
       uses: turtlebrowser/get-conan@v1.2
+
+    - name: Install GitHub Release
+      uses: tcnksm/ghr@latest
       
     - name: Initialize VS Dev Env
       uses: seanmiddleditch/gha-setup-vsdevenv@master
@@ -39,6 +42,10 @@ jobs:
       run: |
         conan profile detect -f
         conan create . --build=missing -pr conan/profiles/${{ matrix.profile }}  -o shared=${{ matrix.shared }} -o with_docs=False -o cpack=True
+
+    - name: Release verion if tagged
+      run: |
+        ghr -t 
 
   build_linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       uses: turtlebrowser/get-conan@v1.2
 
     - name: Install GitHub Release
-      uses: tcnksm/ghr@latest
+      uses: tcnksm/ghr@v0.16.0
       
     - name: Initialize VS Dev Env
       uses: seanmiddleditch/gha-setup-vsdevenv@master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,8 @@ jobs:
     - name: Install Conan
       uses: turtlebrowser/get-conan@v1.2
 
-    - name: Install GitHub Release
-      uses: tcnksm/ghr@v0.16.0
+#    - name: Install GitHub Release
+#      uses: tcnksm/ghr@v0.16.0
       
     - name: Initialize VS Dev Env
       uses: seanmiddleditch/gha-setup-vsdevenv@master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,9 +43,9 @@ jobs:
         conan profile detect -f
         conan create . --build=missing -pr conan/profiles/${{ matrix.profile }}  -o shared=${{ matrix.shared }} -o with_docs=False -o cpack=True
 
-    - name: Release verion if tagged
-      run: |
-        ghr -t 
+#    - name: Release verion if tagged
+#      run: |
+#        ghr -t 
 
   build_linux:
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 set(AGENT_VERSION_MAJOR 2)
 set(AGENT_VERSION_MINOR 2)
 set(AGENT_VERSION_PATCH 0)
-set(AGENT_VERSION_BUILD 3)
+set(AGENT_VERSION_BUILD 4)
 set(AGENT_VERSION_RC "")
 
 # This minimum version is to support Visual Studio 2017 and C++ feature checking and FetchContent

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 # The version number.
 set(AGENT_VERSION_MAJOR 2)
 set(AGENT_VERSION_MINOR 2)
-set(AGENT_VERSION_PATCH 0)
-set(AGENT_VERSION_BUILD 2)
-set(AGENT_VERSION_RC "_RC5")
+set(AGENT_VERSION_PATCH 1)
+set(AGENT_VERSION_BUILD 0)
+set(AGENT_VERSION_RC "_RC1")
 
 # This minimum version is to support Visual Studio 2017 and C++ feature checking and FetchContent
 cmake_minimum_required(VERSION 3.23 FATAL_ERROR)
@@ -14,8 +14,8 @@ if(POLICY CMP0077)
   cmake_policy(SET CMP0077 NEW)
 endif()
 
-option(AGENT_ENABLE_UNITTESTS "Enables the agent's unit tests" ON)
 option(SHARED_AGENT_LIB "Generate shared agent library. Conan options: shared" OFF)
+option(INCLUDE_TESTS "Used for development, includes tests as a subdirectory instead of a package" OFF)
 set(AGENT_PREFIX "" CACHE STRING "Prefix for the name of the agent and the agent library: suggested 'mtc'")
 
 message(INFO " Shared build: ${SHARED_AGENT_LIB}")
@@ -72,11 +72,14 @@ include(cmake/ClangTidy.cmake)
 # Add our projects
 add_subdirectory(agent_lib)
 add_subdirectory(agent)
-if(AGENT_ENABLE_UNITTESTS)
-  enable_testing()
-endif()
 
 include(cmake/ide_integration.cmake)
+
+if(INCLUDE_TESTS)
+  message(STATUS "Including test package as part of the build")
+  enable_testing()
+  add_subdirectory(test_package test)
+endif()
 
 create_clangformat_target()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ if(POLICY CMP0077)
 endif()
 
 option(SHARED_AGENT_LIB "Generate shared agent library. Conan options: shared" OFF)
-option(INCLUDE_TESTS "Used for development, includes tests as a subdirectory instead of a package" OFF)
+option(DEVELOPMENT "Used for development, includes tests as a subdirectory instead of a package" OFF)
 set(AGENT_PREFIX "" CACHE STRING "Prefix for the name of the agent and the agent library: suggested 'mtc'")
 
 message(INFO " Shared build: ${SHARED_AGENT_LIB}")
@@ -75,8 +75,8 @@ add_subdirectory(agent)
 
 include(cmake/ide_integration.cmake)
 
-if(INCLUDE_TESTS)
-  message(STATUS "Including test package as part of the build")
+if(DEVELOPMENT)
+  message(STATUS "Including test package as part of the build for development")
   enable_testing()
   add_subdirectory(test_package test)
 endif()

--- a/conanfile.py
+++ b/conanfile.py
@@ -12,7 +12,7 @@ class MTConnectAgentConan(ConanFile):
     url = "https://github.com/mtconnect/cppagent.git"
     license = "Apache License 2.0"
     settings = "os", "compiler", "arch", "build_type"
-    options = { "without_ipv6": [True, False], "with_ruby": [True, False],
+    options = { "without_ipv6": [True, False], "with_ruby": [True, False], "include_tests": [True, False],
                  "development" : [True, False], "shared": [True, False], "winver": [None, "ANY"],
                  "with_docs" : [True, False], "cpack": [True, False], "agent_prefix": [None, "ANY"],
                  "fPIC": [True, False] }
@@ -29,6 +29,7 @@ class MTConnectAgentConan(ConanFile):
         "cpack": False,
         "agent_prefix": None,
         "fPIC": True,
+        "include_tests": False,
 
         "boost*:shared": False,
         "boost*:without_python": True,
@@ -134,6 +135,7 @@ class MTConnectAgentConan(ConanFile):
         tc.cache_variables['WITH_RUBY'] = self.options.with_ruby.__bool__()
         tc.cache_variables['AGENT_WITH_DOCS'] = self.options.with_docs.__bool__()
         tc.cache_variables['AGENT_WITHOUT_IPV6'] = self.options.without_ipv6.__bool__()
+        tc.cache_variables['INCLUDE_TESTS'] = self.options.include_tests.__bool__()
         if self.options.agent_prefix:
             tc.cache_variables['AGENT_PREFIX'] = self.options.agent_prefix
         if is_msvc(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -12,7 +12,7 @@ class MTConnectAgentConan(ConanFile):
     url = "https://github.com/mtconnect/cppagent.git"
     license = "Apache License 2.0"
     settings = "os", "compiler", "arch", "build_type"
-    options = { "without_ipv6": [True, False], "with_ruby": [True, False], "include_tests": [True, False],
+    options = { "without_ipv6": [True, False], "with_ruby": [True, False], 
                  "development" : [True, False], "shared": [True, False], "winver": [None, "ANY"],
                  "with_docs" : [True, False], "cpack": [True, False], "agent_prefix": [None, "ANY"],
                  "fPIC": [True, False] }
@@ -29,7 +29,6 @@ class MTConnectAgentConan(ConanFile):
         "cpack": False,
         "agent_prefix": None,
         "fPIC": True,
-        "include_tests": False,
 
         "boost*:shared": False,
         "boost*:without_python": True,
@@ -135,7 +134,7 @@ class MTConnectAgentConan(ConanFile):
         tc.cache_variables['WITH_RUBY'] = self.options.with_ruby.__bool__()
         tc.cache_variables['AGENT_WITH_DOCS'] = self.options.with_docs.__bool__()
         tc.cache_variables['AGENT_WITHOUT_IPV6'] = self.options.without_ipv6.__bool__()
-        tc.cache_variables['INCLUDE_TESTS'] = self.options.include_tests.__bool__()
+        tc.cache_variables['DEVELOPMENT'] = self.options.development.__bool__()
         if self.options.agent_prefix:
             tc.cache_variables['AGENT_PREFIX'] = self.options.agent_prefix
         if is_msvc(self):

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.23 FATAL_ERROR)
 
-project(mtconnect_agent_tests LANGUAGES CXX)
+if(NOT INCLUDE_TESTS)
+  project(mtconnect_agent_tests LANGUAGES CXX)
+endif()
 
 set(USE_FOLDERS ON)
 
@@ -8,28 +10,35 @@ if(POLICY CMP0077)
   cmake_policy(SET CMP0077 NEW)
 endif()
 
-include(../cmake/remove_link_directories.cmake)
-include(../cmake/osx_no_app_or_frameworks.cmake)
-include(../cmake/ClangFormat.cmake)
-include(../cmake/ClangTidy.cmake)
+message(STATUS "Include tests: ${INCLUDE_TESTS}")
 
-include(GoogleTest)
-enable_testing()
+if(NOT INCLUDE_TESTS)
+  include(../cmake/remove_link_directories.cmake)
+  include(../cmake/osx_no_app_or_frameworks.cmake)
+  include(../cmake/ClangFormat.cmake)
+  include(../cmake/ClangTidy.cmake)
+
+  find_package(Boost REQUIRED  GLOBAL)
+  find_package(LibXml2 REQUIRED  GLOBAL)
+  find_package(date REQUIRED  GLOBAL)
+  find_package(OpenSSL REQUIRED  GLOBAL)
+  find_package(nlohmann_json REQUIRED GLOBAL)
+  find_package(mqtt_cpp REQUIRED GLOBAL)
+  find_package(RapidJSON REQUIRED GLOBAL)
+  find_package(mtconnect_agent REQUIRED GLOBAL)
+
+  enable_testing()
+endif()
 
 find_package(GTest REQUIRED GLOBAL)
-find_package(Boost REQUIRED  GLOBAL)
-find_package(LibXml2 REQUIRED  GLOBAL)
-find_package(date REQUIRED  GLOBAL)
-find_package(OpenSSL REQUIRED  GLOBAL)
-find_package(nlohmann_json REQUIRED GLOBAL)
-find_package(mqtt_cpp REQUIRED GLOBAL)
-find_package(RapidJSON REQUIRED GLOBAL)
-find_package(mtconnect_agent REQUIRED GLOBAL)
+include(GoogleTest)
 
 #### Sink Plugin Test
 
 set(COMMON_DEFINITIONS 
-  "PROJECT_ROOT_DIR=\"${CMAKE_SOURCE_DIR}\";TEST_RESOURCE_DIR=\"${CMAKE_SOURCE_DIR}/resources\";BOOST_FILESYSTEM_VERSION=3;$<$<BOOL:$ENV{APPVEYOR}>:APPVEYOR>;$<$<PLATFORM_ID:Windows>:NOMINMAX>;$<$<PLATFORM_ID:Windows>:WINVER=${WINVER}>;$<$<PLATFORM_ID:Windows>:_WIN32_WINNT=${WINVER}>")
+  "PROJECT_ROOT_DIR=$<IF:$<BOOL:INCLUDE_TESTS>,\"${CMAKE_SOURCE_DIR}\",\"${CMAKE_SOURCE_DIR}/..\">;BOOST_FILESYSTEM_VERSION=3;$<$<BOOL:$ENV{APPVEYOR}>:APPVEYOR>;$<$<PLATFORM_ID:Windows>:NOMINMAX>;$<$<PLATFORM_ID:Windows>:WINVER=${WINVER}>;$<$<PLATFORM_ID:Windows>:_WIN32_WINNT=${WINVER}>;TEST_RESOURCE_DIR=$<IF:$<BOOL:INCLUDE_TESTS>,\"${CMAKE_SOURCE_DIR}/test_package/resources\",\"${CMAKE_SOURCE_DIR}/resources\">")
+
+message(STATUS "Common definitions: ${COMMON_DEFINITIONS}")
 
 list(REMOVE_ITEM CMAKE_INCLUDE_PATH "include")
 
@@ -50,12 +59,21 @@ target_compile_features(sink_plugin_test
   ${CXX_COMPILE_FEATURES}
   )
 
-target_link_libraries(
-  sink_plugin_test
-  PRIVATE
-  mtconnect_agent::mtconnect_agent
-  $<$<PLATFORM_ID:Windows>:shlwapi>
-  )
+if(INCLUDE_TESTS)
+  target_link_libraries(
+    sink_plugin_test
+    PRIVATE
+    agent_lib
+    $<$<PLATFORM_ID:Windows>:shlwapi>
+    )
+else()
+  target_link_libraries(
+    sink_plugin_test
+    PRIVATE
+    mtconnect_agent::mtconnect_agent
+    $<$<PLATFORM_ID:Windows>:shlwapi>
+    )
+endif()
 target_clangformat_setup(sink_plugin_test)
 
 set_target_properties(sink_plugin_test PROPERTIES FOLDER "test/sink")
@@ -95,14 +113,23 @@ endif()
 
 target_compile_features(adapter_plugin_test PUBLIC ${CXX_COMPILE_FEATURES})
 
-target_link_libraries(
-  adapter_plugin_test
-  PRIVATE
-  mtconnect_agent::mtconnect_agent
-  $<$<PLATFORM_ID:Windows>:shlwapi>
-  )
+if(INCLUDE_TESTS)
+  target_link_libraries(
+    adapter_plugin_test
+    PRIVATE
+    agent_lib
+    $<$<PLATFORM_ID:Windows>:shlwapi>
+    )
+else()
+  target_link_libraries(
+    adapter_plugin_test
+    PRIVATE
+    mtconnect_agent::mtconnect_agent
+    $<$<PLATFORM_ID:Windows>:shlwapi>
+    )
+endif()
 
-set_target_properties(adapter_plugin_test PROPERTIES FOLDER "test_package/adapter")
+set_target_properties(adapter_plugin_test PROPERTIES FOLDER "test/adapter")
 
 target_clangformat_setup(adapter_plugin_test)
 
@@ -116,12 +143,21 @@ target_include_directories(
     "${CMAKE_INCLUDE_PATH}"
     )
 
-target_link_libraries(
-  agent_test_lib
-  PUBLIC
-  mtconnect_agent::mtconnect_agent
-  GTest::GTest
-  )
+if(INCLUDE_TESTS)
+  target_link_libraries(
+    agent_test_lib
+    PUBLIC
+    agent_lib
+    GTest::GTest
+    )
+else()
+  target_link_libraries(
+    agent_test_lib
+    PUBLIC
+    mtconnect_agent::mtconnect_agent
+    GTest::GTest
+    )
+endif()
 
 target_compile_definitions(agent_test_lib PUBLIC ${COMMON_DEFINITIONS})
 target_clangtidy_setup(agent_test_lib)
@@ -134,8 +170,7 @@ macro(add_agent_test AGENT_TEST_NAME ADD_TEST_HELPER SUB_FOLDER)
   set(_sources ${AGENT_TEST_NAME}_test.cpp)
   add_executable(${AGENT_TEST_NAME}_test ${_sources})
   # set_property(TARGET ${AGENT_TEST_NAME}_test PROPERTY LINK_FLAGS_DEBUG "${COVERAGE_FLAGS}")
-  target_link_libraries(${AGENT_TEST_NAME}_test agent_test_lib
-  
+  target_link_libraries(${AGENT_TEST_NAME}_test agent_test_lib  
     $<$<PLATFORM_ID:Linux>:pthread>
     $<$<PLATFORM_ID:Windows>:bcrypt>
     GTest::GTest)
@@ -147,7 +182,7 @@ macro(add_agent_test AGENT_TEST_NAME ADD_TEST_HELPER SUB_FOLDER)
   target_compile_features(${AGENT_TEST_NAME}_test PUBLIC ${CXX_COMPILE_FEATURES})
 
   # Organize into folders
-  set_target_properties(${AGENT_TEST_NAME}_test PROPERTIES FOLDER "test_package/${SUB_FOLDER}")
+  set_target_properties(${AGENT_TEST_NAME}_test PROPERTIES FOLDER "test/${SUB_FOLDER}")
 
   gtest_discover_tests(${AGENT_TEST_NAME}_test DISCOVERY_MODE PRE_TEST)
 

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.23 FATAL_ERROR)
 
+option(INCLUDE_TESTS "Used for development, includes tests as a subdirectory instead of a package" OFF)
+message(STATUS "Include tests: ${INCLUDE_TESTS}")
+
 if(NOT INCLUDE_TESTS)
   project(mtconnect_agent_tests LANGUAGES CXX)
 endif()
@@ -10,10 +13,10 @@ if(POLICY CMP0077)
   cmake_policy(SET CMP0077 NEW)
 endif()
 
-option(INCLUDE_TESTS "Used for development, includes tests as a subdirectory instead of a package" OFF)
-message(STATUS "Include tests: ${INCLUDE_TESTS}")
-
-if(NOT INCLUDE_TESTS)
+if (INCLUDE_TESTS)
+  file(REAL_PATH ${CMAKE_SOURCE_DIR} project_root_dir)
+  file(REAL_PATH "${CMAKE_SOURCE_DIR}/test_package/resources" test_resource_dir)
+else()
   include(../cmake/remove_link_directories.cmake)
   include(../cmake/osx_no_app_or_frameworks.cmake)
   include(../cmake/ClangFormat.cmake)
@@ -29,23 +32,23 @@ if(NOT INCLUDE_TESTS)
   find_package(mtconnect_agent REQUIRED GLOBAL)
 
   enable_testing()
+
+  file(REAL_PATH "${CMAKE_SOURCE_DIR}/.." project_root_dir)
+  file(REAL_PATH "${CMAKE_SOURCE_DIR}/resources" test_resource_dir)
 endif()
 
 find_package(GTest REQUIRED GLOBAL)
 include(GoogleTest)
 
-#### Sink Plugin Test
-
-file(REAL_PATH "$<IF:$<BOOL:INCLUDE_TESTS>,\"${CMAKE_SOURCE_DIR}\",\"${CMAKE_SOURCE_DIR}/..\">" project_root_dir)
-file(REAL_PATH "$<IF:$<BOOL:INCLUDE_TESTS>,\"${CMAKE_SOURCE_DIR}/test_package/resources\",\"${CMAKE_SOURCE_DIR}/resources\">" test_resource_dir)
-
 message(STATUS "Project Root: ${project_root_dir}")
 message(STATUS "Test Resources: ${test_resource_dir}")
 
 set(COMMON_DEFINITIONS 
-  "PROJECT_ROOT_DIR=$<IF:$<BOOL:INCLUDE_TESTS>,\"${CMAKE_SOURCE_DIR}\",\"${CMAKE_SOURCE_DIR}/..\">;BOOST_FILESYSTEM_VERSION=3;$<$<BOOL:$ENV{APPVEYOR}>:APPVEYOR>;$<$<PLATFORM_ID:Windows>:NOMINMAX>;$<$<PLATFORM_ID:Windows>:WINVER=${WINVER}>;$<$<PLATFORM_ID:Windows>:_WIN32_WINNT=${WINVER}>;TEST_RESOURCE_DIR=$<IF:$<BOOL:INCLUDE_TESTS>,\"${CMAKE_SOURCE_DIR}/test_package/resources\",\"${CMAKE_SOURCE_DIR}/resources\">")
+  "PROJECT_ROOT_DIR=\"${project_root_dir}\";BOOST_FILESYSTEM_VERSION=3;$<$<BOOL:$ENV{APPVEYOR}>:APPVEYOR>;$<$<PLATFORM_ID:Windows>:NOMINMAX>;$<$<PLATFORM_ID:Windows>:WINVER=${WINVER}>;$<$<PLATFORM_ID:Windows>:_WIN32_WINNT=${WINVER}>;TEST_RESOURCE_DIR=\"${test_resource_dir}\"")
 
 message(STATUS "Common definitions: ${COMMON_DEFINITIONS}")
+
+#### Sink Plugin Test
 
 list(REMOVE_ITEM CMAKE_INCLUDE_PATH "include")
 

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 3.23 FATAL_ERROR)
 
-option(INCLUDE_TESTS "Used for development, includes tests as a subdirectory instead of a package" OFF)
-message(STATUS "Include tests: ${INCLUDE_TESTS}")
+option(DEVELOPMENT "Used for development, includes tests as a subdirectory instead of a package" OFF)
+message(STATUS "Development: ${DEVELOPMENT}")
 
-if(NOT INCLUDE_TESTS)
+if(NOT DEVELOPMENT)
   project(mtconnect_agent_tests LANGUAGES CXX)
 endif()
 
@@ -13,7 +13,7 @@ if(POLICY CMP0077)
   cmake_policy(SET CMP0077 NEW)
 endif()
 
-if (INCLUDE_TESTS)
+if (DEVELOPMENT)
   file(REAL_PATH ${CMAKE_SOURCE_DIR} project_root_dir)
   file(REAL_PATH "${CMAKE_SOURCE_DIR}/test_package/resources" test_resource_dir)
 else()
@@ -69,7 +69,7 @@ target_compile_features(sink_plugin_test
   ${CXX_COMPILE_FEATURES}
   )
 
-if(INCLUDE_TESTS)
+if(DEVELOPMENT)
   target_link_libraries(
     sink_plugin_test
     PRIVATE
@@ -123,7 +123,7 @@ endif()
 
 target_compile_features(adapter_plugin_test PUBLIC ${CXX_COMPILE_FEATURES})
 
-if(INCLUDE_TESTS)
+if(DEVELOPMENT)
   target_link_libraries(
     adapter_plugin_test
     PRIVATE
@@ -153,7 +153,7 @@ target_include_directories(
     "${CMAKE_INCLUDE_PATH}"
     )
 
-if(INCLUDE_TESTS)
+if(DEVELOPMENT)
   target_link_libraries(
     agent_test_lib
     PUBLIC

--- a/test_package/config_test.cpp
+++ b/test_package/config_test.cpp
@@ -443,14 +443,12 @@ namespace {
 
   TEST_F(ConfigTest, SchemaDirectory)
   {
-    chdir(PROJECT_ROOT_DIR);
-    m_config->updateWorkingDirectory();
     string schemas(
         "SchemaVersion = 1.3\n"
         "Files {\n"
         "schemas {\n"
         "Location = /schemas\n"
-        "Path = ../schemas\n"
+        "Path = " PROJECT_ROOT_DIR "/schemas\n"
         "}\n"
         "}\n"
         "logger_config {\n"


### PR DESCRIPTION
Made option `development` for use with `conan build ...` command. This includes the `test_package` as part of the top level project useful for writing code and tests simultaneously. 

When `conan create` is used, the `test_package` is treated as a separate package the pulls in the `mtconnect_agent`.

This should make it easier to test and validate builds while still verifying the use of the mtconnect agent as an embedded library.