### PR TITLE
Add deploy release cd workflow

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -16,16 +16,15 @@
 name: Build Docker image
 
 env:
-  VERSION: 2.0.0.8
   PLATFORMS: linux/amd64,linux/arm64
 
 # when to run workflow
 on:
   # # run on push or pull request events for the master branch
   # push:
-  #   branches: [ master ]
+  #   branches: [ main ]
   # pull_request:
-  #   branches: [ master ]
+  #   branches: [ main ]
 
   # allows you to run this workflow manually from the actions tab
   workflow_dispatch:
@@ -41,10 +40,8 @@ jobs:
     steps:
       # checks-out your repository under $GITHUB_WORKSPACE
       # see https://github.com/actions/checkout
-      - uses: actions/checkout@v3
-        with:
-          ref: v${{ env.VERSION }}
-          # ref: master
+      - name: Checkout Agent
+        uses: actions/checkout@v3
 
       # the QEMU emulator lets us build for arm processors also
       # see https://github.com/docker/setup-qemu-action
@@ -72,7 +69,7 @@ jobs:
           # docker hub user/repo:tag
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/agent:latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/agent:${{ env.VERSION }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/agent:${{ github.ref_name }}
 
           # push to docker hub
           push: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,11 +29,11 @@ jobs:
     - name: Checkout Agent
       uses: actions/checkout@v3
 
-    - name: Cache node modules
+    - name: Cache conan packages
       id: cache-npm
       uses: actions/cache@v3
       env:
-       cache-name: cache-node-modules
+       cache-name: cache-conan-packages
       with:
         path: ~/.conan2
         key: ${{ runner.os }}-build-${{ matrix.shared }}-${{ hashFiles('**/conanfile.py') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Build and Test C++ Agent
       run: |
         conan profile detect -f
-        conan create . --build=missing -pr conan/profiles/${{ matrix.profile }}  -o shared=${{ matrix.shared }} -o with_docs=False -o cpack=True -o zip_destination=C:\Users\runneradmin\
+        conan create . --build=missing -pr conan/profiles/${{ matrix.profile }} -o with_docs=False -o cpack=True -o zip_destination=C:\Users\runneradmin\
 
   build_linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,14 @@
+# Build, Test, and Draft Releae for static and dynamic versions of the
+# MTConnect Agent on Windows, Mac OS, and Linux. 
+#
+# The Windows x86 and x86_64 builds create ZIP packages and attach them to
+# a draft release when the commit is tagged.
+#
+# Secret required for Release:
+#   RELEASE_GITHUB_TOKEN - Release token created by admin in Settings / Developer Settings / Personal access tokens /
+#                            Find-grained tokens
+#                          The token must be renewed every 90 days.
+
 name: Build MTConnect C++ Agent
 
 on:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ on:
   push:
     paths-ignore: ["**/*.md", "LICENSE.txt", ".gitignore"]
     branches: [ "main", "main-dev" ]
+    tags:
+      - "v*.*.*"
 
   # Allow manually run workflows
   workflow_dispatch:
@@ -19,32 +21,43 @@ jobs:
     strategy:
       matrix:
         arch: ["x86", "amd64"]
+        shared: ["True", "False"]
         include:
           - arch: "x86"
             profile: "vs32"
           - arch: "amd64"
             profile: "vs64"
-
-# Shared build will be reenabled once I figure why one of the tests is failing
-#        shared: ["False", "True"]
-#        include:
-#          - shared: "False"
-#            profile: "vs64"
-#          - shared: "True"
-#            profile: "vs64shared"
+          - shared: "True"
+            profile: "vs64shared"
+        exclude:
+          - arch: "x86"
+            shared: "True"
 
     steps:
+    - name: Setup conan and zip directories
+      run: |
+        ruby -e @"
+          base = ENV['GITHUB_WORKSPACE'].gsub('\\', '/').
+            gsub(/\/[a-zA-Z]+$/, '')
+          
+          puts %{ZIP_DIR=#{base}}
+          puts %{CONAN_HOME=#{base}/conan2}
+        "@ >> $env:GITHUB_ENV
+              
+    - name: Print Directories
+      run: |
+        echo $CONAN_HOME
+        echo $ZIP_DIR
+              
     - name: Checkout Agent
       uses: actions/checkout@v3
 
     - name: Cache conan packages
-      id: cache-npm
+      id: cache
       uses: actions/cache@v3
-      env:
-       cache-name: cache-conan-packages
       with:
-        path: ~/.conan2
-        key: ${{ runner.os }}-build-${{ matrix.arch }}-${{ hashFiles('**/conanfile.py') }}
+        path: ${{ env.CONAN_HOME }}
+        key: ${{ runner.os }}-build-${{ matrix.profile }}-${{ hashFiles('**/conanfile.py') }}
 
     - name: Install Conan
       uses: turtlebrowser/get-conan@v1.2
@@ -54,12 +67,32 @@ jobs:
       with:
         arch: ${{ matrix.arch }}
         host_arch: ${{ matrix.arch }}
-          
-    - name: Build and Test C++ Agent
+
+    - name: Setup Conan
+      if: steps.cache.outputs.cache-hit != 'true'
       run: |
         conan profile detect -f
-        conan create . --build=missing -pr conan/profiles/${{ matrix.profile }} -o with_docs=False -o cpack=True -o zip_destination=C:\Users\runneradmin\
+      
+    - name: Cleanup Prior Build
+      if: steps.cache.outputs.cache-hit == 'true'
+      continue-on-error: true
+      run: |
+        conan remove mtconnect_agent -c
 
+    - name: Build and Test C++ Agent
+      run: |
+        conan create . --build=missing -pr conan/profiles/${{ matrix.profile }} -o with_docs=False -o cpack=True -o zip_destination=$ZIP_DIR -o shared=${{ matrix.shared }}
+
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      if: ${{ startsWith(github.ref, 'refs/tags/') && matrix.shared == 'False' }}
+      with:
+        name: Version ${{ github.ref_name }}
+        draft: true
+        files: |
+          ${{ env.ZIP_DIR }}/agent*.zip
+        token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+        
   build_linux:
     runs-on: ubuntu-latest
     strategy:
@@ -67,22 +100,39 @@ jobs:
         shared: ["True", "False"]
             
     steps:
-    - name: Checkout Agent
-      uses: actions/checkout@v3
-
     - name: Install dependencies
       shell: bash
       run: |
         sudo apt install -y build-essential cmake gcc-11 g++-11 python3 autoconf automake
       
+    - name: Checkout Agent
+      uses: actions/checkout@v3
+
+    - name: Cache conan packages
+      id: cache
+      uses: actions/cache@v3
+      with:
+        path: ~/.conan2
+        key: ${{ runner.os }}-build-${{ matrix.shared }}-${{ hashFiles('**/conanfile.py') }}
+                      
     - name: Install Conan
       uses: turtlebrowser/get-conan@v1.2
       
+    - name: Setup Conan
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        conan profile detect -f
+      
+    - name: Cleanup Prior Build
+      if: steps.cache.outputs.cache-hit == 'true'
+      continue-on-error: true
+      run: |
+        conan remove mtconnect_agent -c
+
     - name: Build and Test C++ Agent
       shell: bash
       run: |
-        conan profile detect -f
-        conan create . --build=missing -pr conan/profiles/gcc  -o shared=${{ matrix.shared }} -o with_docs=False -o cpack=True
+        conan create . --build=missing -pr conan/profiles/gcc  -o shared=${{ matrix.shared }} -o with_docs=False
         
   build_macos:
     runs-on: macos-latest
@@ -94,14 +144,29 @@ jobs:
     - name: Checkout Agent
       uses: actions/checkout@v3
 
+    - name: Cache conan packages
+      id: cache
+      uses: actions/cache@v3
+      with:
+        path: ~/.conan2
+        key: ${{ runner.os }}-build-${{ matrix.shared }}-${{ hashFiles('**/conanfile.py') }}
+                      
     - name: Install Conan
       uses: turtlebrowser/get-conan@v1.2
       
+    - name: Setup Conan
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        conan profile detect -f
+      
+    - name: Cleanup Prior Build
+      if: steps.cache.outputs.cache-hit == 'true'
+      continue-on-error: true
+      run: |
+        conan remove mtconnect_agent -c
+
     - name: Build and Test C++ Agent
       shell: bash
       run: |
-        conan profile detect -f
-        conan create . --build=missing -pr conan/profiles/macos  -o shared=${{ matrix.shared }} -o with_docs=False -o cpack=True
+        conan create . --build=missing -pr conan/profiles/macos  -o shared=${{ matrix.shared }} -o with_docs=False
         
-        
-    

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,12 +18,20 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        shared: ["False", "True"]
+        arch: ["x86", "amd64"]
         include:
-          - shared: "False"
+          - arch: "x86"
+            profile: "vs32"
+          - arch: "amd64"
             profile: "vs64"
-          - shared: "True"
-            profile: "vs64shared"
+
+# Shared build will be reenabled once I figure why one of the tests is failing
+#        shared: ["False", "True"]
+#        include:
+#          - shared: "False"
+#            profile: "vs64"
+#          - shared: "True"
+#            profile: "vs64shared"
 
     steps:
     - name: Checkout Agent
@@ -36,14 +44,17 @@ jobs:
        cache-name: cache-conan-packages
       with:
         path: ~/.conan2
-        key: ${{ runner.os }}-build-${{ matrix.shared }}-${{ hashFiles('**/conanfile.py') }}
+        key: ${{ runner.os }}-build-${{ matrix.arch }}-${{ hashFiles('**/conanfile.py') }}
 
     - name: Install Conan
       uses: turtlebrowser/get-conan@v1.2
 
     - name: Initialize VS Dev Env
       uses: seanmiddleditch/gha-setup-vsdevenv@master
-
+      with:
+        arch: ${{ matrix.arch }}
+        host_arch: ${{ matrix.arch }}
+          
     - name: Build and Test C++ Agent
       run: |
         conan profile detect -f

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,16 +85,22 @@ endif()
 
 create_clangformat_target()
 
+include(GNUInstallDirs)
+
+if(NOT MSVC)
+  set(CMAKE_INSTALL_DATADIR "share/mtconnect")
+endif()
+
 # For Visual Studio generators it is now possible (since V3.6) to set a default startup project.
 # We will set this to the agent_test project.
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT agent)
 
-install(FILES README.md LICENSE.TXT DESTINATION . )
-install(DIRECTORY schemas DESTINATION . )
-install(DIRECTORY simulator DESTINATION . )
-install(DIRECTORY styles DESTINATION . )
-install(DIRECTORY tools DESTINATION . )
-install(DIRECTORY demo DESTINATION . )
+install(FILES README.md LICENSE.TXT TYPE DATA)
+install(DIRECTORY schemas TYPE DATA)
+install(DIRECTORY simulator TYPE DATA)
+install(DIRECTORY styles TYPE DATA)
+install(DIRECTORY tools TYPE DATA)
+install(DIRECTORY demo TYPE DATA)
 
 set(CPACK_COMPONENTS_ALL_IN_ONE_PACKAGE 1)
 set(CPACK_PACKAGE_VERSION "${AGENT_VERSION_MAJOR}.${AGENT_VERSION_MINOR}.${AGENT_VERSION_PATCH}.${AGENT_VERSION_BUILD}${AGENT_VERSION_RC}")

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ FROM os AS build
 # limit cpus so don't run out of memory on local machine
 # symptom: get error - "c++: fatal error: Killed signal terminated program cc1plus"
 # can turn off if building in cloud
-ARG CONAN_CPU_COUNT=10
+ARG CONAN_CPU_COUNT=2
 
 ARG WITH_RUBY='True'
 
@@ -113,7 +113,7 @@ USER agent
 WORKDIR /home/agent
 
 # install agent executable
-COPY --chown=agent:agent --from=build /root/agent/build/bin/agent /usr/local/bin/
+COPY --chown=agent:agent --from=build /root/agent/*.zip .
 
 # Extract the data
 RUN unzip *.zip
@@ -122,14 +122,14 @@ RUN unzip *.zip
 USER root
 RUN cp /home/agent/agent-*-Linux/bin/* "$BIN_DIR" \
   && mkdir -p "$MTCONNECT_DIR" \
-  && chown -R agent:agent "$MTCONNECT_DIR"
+  && chown agent:agent "$MTCONNECT_DIR"
 
 USER agent
 
-RUN cp -r /home/agent/agent-*-Linux/schemas \
-  /home/agent/agent-*-Linux/simulator \
-  /home/agent/agent-*-Linux/styles \
-  /home/agent/agent-*-Linux/demo \
+RUN cp -r /home/agent/agent-*-Linux/share/mtconnect/schemas \
+  /home/agent/agent-*-Linux/share/mtconnect/simulator \
+  /home/agent/agent-*-Linux/share/mtconnect/styles \
+  /home/agent/agent-*-Linux/share/mtconnect/demo \
   "$MTCONNECT_DIR"
 
 # expose port

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,11 +37,21 @@ FROM os AS build
 
 # update os and add dependencies
 # note: Dockerfiles run as root by default, so don't need sudo
-RUN apt-get clean \
+RUN  apt-get clean \
   && apt-get update \
   && apt-get install -y \
-  build-essential python3.9 python3-pip git cmake make ruby rake autoconf automake \
-  && pip install conan -v "conan==2.0.9"
+       autoconf \
+       automake \
+       build-essential \
+       cmake \
+       git \
+       python3 \
+       python3-pip \
+       rake \
+       ruby
+
+# Install conan version 2.0.9
+RUN pip install conan -v "conan==2.0.9"
 
 # make an agent directory and cd into it
 WORKDIR /root/agent
@@ -58,13 +68,10 @@ ARG WITH_TESTS=False
 ARG CONAN_CPU_COUNT=2
 
 # set some variables
-ENV PATH=$HOME/venv3.9/bin:$PATH
 ENV CONAN_PROFILE=conan/profiles/docker
 
 # make installer
 RUN conan profile detect
-RUN conan install . --build=missing -pr $CONAN_PROFILE -o with_ruby=$WITH_RUBY -c tools.build:skip_test=True \
-     -c tools.build:jobs=$CONAN_CPU_COUNT
 RUN conan create . --build=missing -pr $CONAN_PROFILE -o with_ruby=$WITH_RUBY -o cpack=True \
       -o zip_destination=/root/agent -o agent_prefix=mtc \
       -c tools.build:skip_test=True -tf "" -c tools.build:jobs=$CONAN_CPU_COUNT
@@ -82,7 +89,7 @@ ARG MTCONNECT_DIR=/etc/mtconnect
 ENV MTCONNECT_DIR=$MTCONNECT_DIR
 
 # install ruby for simulator
-RUN apt-get update && apt-get install -y ruby zip
+RUN apt-get clean && apt-get update && apt-get install -y ruby zip
 
 # change to a new non-root user for better security.
 # this also adds the user to a group with the same name.

--- a/agent/CMakeLists.txt
+++ b/agent/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(
 target_clangtidy_setup(agent)
 
 install(TARGETS agent RUNTIME)
+install(TARGETS agent ARCHIVE)
 
 if(SHARED_AGENT_LIB AND MSVC)
   set(CMAKE_INSTALL_DEBUG_LIBRARIES OFF)
@@ -61,5 +62,5 @@ if(SHARED_AGENT_LIB AND MSVC)
 elseif(SHARED_AGENT_LIB)
   file(GLOB dlls CONFIGURE_DEPENDS "${cppagent_BINARY_DIR}/dlls/*.dylib" "${cppagent_BINARY_DIR}/dlls/*.so")
   message(STATUS "!!!!! Copying ${dlls} to lib directory")
-  install(FILES ${dlls} DESTINATION lib COMPONENT Libraries)
+  install(FILES ${dlls} TYPE LIB COMPONENT Libraries)
 endif()

--- a/agent_lib/CMakeLists.txt
+++ b/agent_lib/CMakeLists.txt
@@ -436,10 +436,10 @@ endif()
 
 target_sources(agent_lib PUBLIC FILE_SET headers
   TYPE HEADERS
-  BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/../src/"
-  FILES "${AGENT_LIB_HEADERS}")
+  BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/../src/" "${PROJECT_BINARY_DIR}/agent_lib/"
+  FILES "${AGENT_LIB_HEADERS}" "${PROJECT_BINARY_DIR}/agent_lib/mtconnect/version.h")
+  
 
-install(TARGETS agent_lib LIBRARY DESTINATION "lib")
-install(TARGETS agent_lib ARCHIVE DESTINATION "lib")
-install(TARGETS agent_lib FILE_SET headers DESTINATION "include")
-install(FILES "${PROJECT_BINARY_DIR}/agent_lib/mtconnect/version.h" DESTINATION "include/mtconnect")
+install(TARGETS agent_lib LIBRARY)
+install(TARGETS agent_lib ARCHIVE)
+install(TARGETS agent_lib FILE_SET headers PUBLIC_HEADER)

--- a/demo/agent/agent.mac
+++ b/demo/agent/agent.mac
@@ -1,0 +1,55 @@
+Devices = Devices.xml
+SchemaVersion = 2.0
+WorkerThreads = 3
+MonitorConfigFiles = yes
+Port = 5001
+JsonVersion = 2
+
+MinCompressFileSize = 10k
+
+Files {
+  schemas {
+    Path = ../../schemas
+    Location = /schemas/
+  }
+  styles {
+    Path = ../../styles
+    Location = /styles/
+  }
+  Favicon {
+      Path = ../../styles/favicon.ico
+      Location = /favicon.ico
+  }
+}
+
+Directories {
+  twin {
+    Path = ../twin/
+    Location = /twin/
+    Default = index.html
+  }
+}
+
+Sinks {
+#  MqttService {
+#  }
+}
+
+DevicesStyle { Location = /styles/styles.xsl }
+StreamsStyle { Location = /styles/styles.xsl }
+
+Adapters {
+  OKUMA {
+    Port = 7878
+    Host = 127.0.0.1
+  }
+  Mazak {
+    Port = 7879
+    Host = 127.0.0.1
+  }
+}
+
+logger_config {
+  output = file agent.log
+  level = warning
+}


### PR DESCRIPTION
* Fixed the docker build and created a new option to generate the cpack zip file to another directory.
  * `-o zip_destination=/home/agent` will create the zip file in the /home/agent directory. 
  * This will also facilitate CD to distribute the zip files as part of the release.
* Development build now runs tests at the end of the `conan build`
* Changes to the cmake install
* Created dependency on cmake 3.26.4