### PR TITLE
Add build args UID and GID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,7 +119,12 @@ RUN apt-get update \
 # change to a new non-root user for better security.
 # this also adds the user to a group with the same name.
 # -m creates a home folder, ie /home/<username>
-RUN useradd -m agent
+ARG UID=1000
+ARG GID=1000
+
+RUN groupadd --gid $GID agent
+RUN useradd --create-home --uid $UID --gid $GID agent
+
 USER agent
 WORKDIR /home/agent
 


### PR DESCRIPTION
This address #314

The Docker image builds with and without build arguments. 

Tested with:
```
docker buildx build --tag mtconnect/agent:2.0.0.12_RC18 .
```
and
```
docker buildx build --build-arg UID=1200 --build-arg GID=1200 --tag mtconnect/agent:2.0.0.12_RC18 .
```
