### PR TITLE
Version 2.2.0.8 – fixed boundry race condition between replay of samp…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 set(AGENT_VERSION_MAJOR 2)
 set(AGENT_VERSION_MINOR 2)
 set(AGENT_VERSION_PATCH 0)
-set(AGENT_VERSION_BUILD 7)
+set(AGENT_VERSION_BUILD 8)
 set(AGENT_VERSION_RC "")
 
 # This minimum version is to support Visual Studio 2019 and C++ feature checking and FetchContent

--- a/src/mtconnect/observation/change_observer.cpp
+++ b/src/mtconnect/observation/change_observer.cpp
@@ -215,7 +215,8 @@ namespace mtconnect::observation {
           // This will allow the next set of data to be pulled. Any later events will have
           // greater sequence numbers, so this should not cause a problem. Also, signaled
           // sequence numbers can only decrease, never increase.
-          m_sequence = m_observer.getSequence();
+          if (m_observer.getSequence() > m_sequence)
+            m_sequence = m_observer.getSequence();
           m_observer.reset();
         }
       }


### PR DESCRIPTION
Fixed the race condition that occurs when the observer is signaled and the previous replay exceeds the signaled observer value. This caused some observations to be repeated at the beginning of the first buffer after the interval.