### PR TITLE
Added Heartbeat to the SHDR adapter to override

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -22,8 +22,6 @@ env:
 on:
   # # run on push or pull request events for the master branch
   push:
-    paths-ignore: ["**/*.md", "LICENSE.txt", ".gitignore"]
-    branches: [ "main", "main-dev" ]
     tags:
       - "v*.*.*"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 set(AGENT_VERSION_MAJOR 2)
 set(AGENT_VERSION_MINOR 2)
 set(AGENT_VERSION_PATCH 0)
-set(AGENT_VERSION_BUILD 10)
+set(AGENT_VERSION_BUILD 11)
 set(AGENT_VERSION_RC "")
 
 # This minimum version is to support Visual Studio 2019 and C++ feature checking and FetchContent

--- a/README.md
+++ b/README.md
@@ -656,6 +656,11 @@ These can be overridden on a per-adapter basis
 
     *Default*: false
     
+* `Heartbeat` – Overrides the heartbeat interval sent back from the adapter in the 
+   `* PONG <hb>`. The heartbeat will always be this value in milliseconds.
+
+    *Default*: _None_
+    
 * `IgnoreTimestamps` - Overwrite timestamps with the agent time. This will correct
   clock drift but will not give as accurate relative time since it will not take into
   consideration network latencies. This can be overridden on a per adapter basis.

--- a/src/mtconnect/configuration/agent_config.cpp
+++ b/src/mtconnect/configuration/agent_config.cpp
@@ -936,6 +936,7 @@ namespace mtconnect::configuration {
                    {{configuration::Url, string()},
                     {configuration::Device, string()},
                     {configuration::UUID, string()},
+                    {configuration::Heartbeat, std::chrono::milliseconds()},
                     {configuration::Uuid, string()}});
 
         if (HasOption(adapterOptions, configuration::Uuid) &&

--- a/src/mtconnect/source/adapter/shdr/connector.hpp
+++ b/src/mtconnect/source/adapter/shdr/connector.hpp
@@ -42,7 +42,8 @@ namespace mtconnect::source::adapter::shdr {
     /// @param reconnectInterval time between reconnection attempts (defaults to 10 seconds)
     Connector(boost::asio::io_context::strand &strand, std::string server, unsigned int port,
               std::chrono::seconds legacyTimout = std::chrono::seconds {600},
-              std::chrono::seconds reconnectInterval = std::chrono::seconds {10});
+              std::chrono::seconds reconnectInterval = std::chrono::seconds {10},
+              std::optional<std::chrono::milliseconds> heartbeat = std::nullopt);
 
     virtual ~Connector();
 
@@ -94,6 +95,8 @@ namespace mtconnect::source::adapter::shdr {
     }
 
     void setRealTime(bool realTime = true) { m_realTime = realTime; }
+    
+    const auto &getHeartbeatOverride() const { return m_heartbeatOverride; }
 
   protected:
     void close();
@@ -146,7 +149,8 @@ namespace mtconnect::source::adapter::shdr {
 
     // Heartbeats
     bool m_heartbeats = false;
-    std::chrono::milliseconds m_heartbeatFrequency = std::chrono::milliseconds {HEARTBEAT_FREQ};
+    std::chrono::milliseconds m_heartbeatFrequency {HEARTBEAT_FREQ};
+    std::optional<std::chrono::milliseconds> m_heartbeatOverride;
     std::chrono::milliseconds m_legacyTimeout;
     std::chrono::milliseconds m_reconnectInterval;
     std::chrono::milliseconds m_receiveTimeLimit;

--- a/src/mtconnect/source/adapter/shdr/shdr_adapter.cpp
+++ b/src/mtconnect/source/adapter/shdr/shdr_adapter.cpp
@@ -48,15 +48,15 @@ namespace mtconnect::source::adapter::shdr {
   {
     GetOptions(block, m_options, options);
     AddOptions(block, m_options,
-               {
-                   {configuration::UUID, string()},
-                   {configuration::Manufacturer, string()},
-                   {configuration::Station, string()},
-                   {configuration::Url, string()},
-               });
+               {{configuration::Heartbeat, Milliseconds {0}},
+                {configuration::UUID, string()},
+                {configuration::Manufacturer, string()},
+                {configuration::Station, string()},
+                {configuration::Url, string()}});
 
     m_options.erase(configuration::Host);
     m_options.erase(configuration::Port);
+    m_heartbeatOverride = GetOption<Milliseconds>(m_options, configuration::Heartbeat);
 
     AddDefaultedOptions(block, m_options,
                         {{configuration::Host, "localhost"s},


### PR DESCRIPTION
* Use `Heartbeat = <hb>` as an override regardless of the value returned in `* PONG <hb>`