### PR TITLE
Fixed issue with publishing conditions without state

### DIFF
--- a/src/mtconnect/entity/json_printer.hpp
+++ b/src/mtconnect/entity/json_printer.hpp
@@ -157,7 +157,7 @@ namespace mtconnect::entity {
         throw std::runtime_error("Invalid json printer version");
     }
 
-    /// @brief Helper method to serialize a list entity list using json version 1 format
+    /// @brief Helper method to serialize an entity list using json version 1 format
     ///
     /// A simple array is created holding entities with the key being the object name and properties
     /// as an object. The keys are repeated for each entity.

--- a/src/mtconnect/sink/mqtt_sink/mqtt_service.cpp
+++ b/src/mtconnect/sink/mqtt_sink/mqtt_service.cpp
@@ -135,7 +135,15 @@ namespace mtconnect {
         auto content = dataItem->getTopicName();                  // client asyn content
 
         // We may want to use the observation from the checkpoint.
-        auto doc = m_jsonPrinter->printEntity(observation);
+        string doc;
+        if (observation->getDataItem()->isCondition())
+        {
+          doc = m_jsonPrinter->print(observation);
+        }
+        else
+        {
+          doc = m_jsonPrinter->printEntity(observation);
+        }
 
         if (m_client)
           m_client->publish(topic, doc);


### PR DESCRIPTION
* Added state as a top level key for conditions:

For example:
```
{"Fault":{"value":"Temperature is too high","dataItemId":"ctmp","nativeCode":"X111","nativeSeverity":"BAD","qualifier":"HIGH","sequence":53,"timestamp":"2018-04-27T05:00:26.555666Z","type":"TEMPERATURE"}}
```