### PR TITLE
chore: add `styles/old` to `.dockerignore`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -24,3 +24,4 @@ terms.tex
 
 *.log
 .DS_Store
+styles/old


### PR DESCRIPTION
This folder is not necessary to copy to the Docker images.

This commit fixes #375.