### PR TITLE
Resolve undefined boost::log symbol using ExtractTimestamp transform 

### DIFF
--- a/src/mtconnect/pipeline/timestamp_extractor.hpp
+++ b/src/mtconnect/pipeline/timestamp_extractor.hpp
@@ -90,8 +90,6 @@ namespace mtconnect::pipeline {
     using namespace date::literals;
     using namespace date;
 
-    NAMED_SCOPE("TimestampExtractor");
-
     // Extract duration
     string_view timestamp {token};
     Timestamp result;


### PR DESCRIPTION
boost log NAMED_SCOPE cannot be used because the boost log is set up differently in the sink DLL. ExtractTimestamp transform has an inline code that uses NAMED_SCOPE..

ld: Undefined symbols:
boost::log::v2_mt_posix::attributes::named_scope::push_scope(boost::log::v2_mt_posix::attributes::named_scope_entry const&), referenced from:
      boost::log::v2_mt_posix::attributes::named_scope::sentry::sentry(boost::log::v2_mt_posix::basic_string_literal<char, std::__1::char_traits<char>> const&, boost::log::v2_mt_posix::basic_string_literal<char, std::__1::char_traits<char>> const&, unsigned int, boost::log::v2_mt_posix::attributes::named_scope_entry::scope_name_type) in 

