### PR TITLE
Added Sender configuration setting and tests closing #409

### DIFF
--- a/src/mtconnect/agent.cpp
+++ b/src/mtconnect/agent.cpp
@@ -113,6 +113,13 @@ namespace mtconnect {
       for (auto &[k, pr] : m_printers)
         pr->setSchemaVersion(*m_schemaVersion);
     }
+    
+    auto sender = GetOption<string>(options, config::Sender);
+    if (sender)
+    {
+      for (auto &[k, pr] : m_printers)
+        pr->setSenderName(*sender);
+    }
   }
 
   void Agent::initialize(pipeline::PipelineContextPtr context)

--- a/src/mtconnect/configuration/config_options.hpp
+++ b/src/mtconnect/configuration/config_options.hpp
@@ -64,6 +64,7 @@ namespace mtconnect {
     DECLARE_CONFIGURATION(SchemaVersion);
     DECLARE_CONFIGURATION(ServerIp);
     DECLARE_CONFIGURATION(ServiceName);
+    DECLARE_CONFIGURATION(Sender);
     DECLARE_CONFIGURATION(TlsCertificateChain);
     DECLARE_CONFIGURATION(TlsCertificatePassword);
     DECLARE_CONFIGURATION(TlsClientCAs);

--- a/src/mtconnect/printer/json_printer.cpp
+++ b/src/mtconnect/printer/json_printer.cpp
@@ -57,22 +57,6 @@ namespace mtconnect::printer {
     m_version = appVersion;
   }
 
-  const string &JsonPrinter::hostname() const
-  {
-    if (m_hostname.empty())
-    {
-      string name;
-      boost::system::error_code ec;
-      name = boost::asio::ip::host_name(ec);
-      if (ec)
-        name = "localhost";
-      // Breaking the rules, this is a one off
-      const_cast<JsonPrinter *>(this)->m_hostname = name;
-    }
-
-    return m_hostname;
-  }
-
   template <typename T>
   inline void header(AutoJsonObject<T> &obj, const string &version, const string &hostname,
                      const uint64_t instanceId, const unsigned int bufferSize,
@@ -138,7 +122,7 @@ namespace mtconnect::printer {
 
         {
           AutoJsonObject obj(writer, "Header");
-          header(obj, m_version, hostname(), instanceId, bufferSize, *m_schemaVersion,
+          header(obj, m_version, m_senderName, instanceId, bufferSize, *m_schemaVersion,
                  m_modelChangeTime);
         }
         {
@@ -195,7 +179,7 @@ namespace mtconnect::printer {
       obj.AddPairs("jsonVersion", m_jsonVersion, "schemaVersion", *m_schemaVersion);
       {
         AutoJsonObject obj(writer, "Header");
-        probeAssetHeader(obj, m_version, hostname(), instanceId, bufferSize, assetBufferSize,
+        probeAssetHeader(obj, m_version, m_senderName, instanceId, bufferSize, assetBufferSize,
                          assetCount, *m_schemaVersion, m_modelChangeTime);
       }
       {
@@ -222,7 +206,7 @@ namespace mtconnect::printer {
       obj.AddPairs("jsonVersion", m_jsonVersion, "schemaVersion", *m_schemaVersion);
       {
         AutoJsonObject obj(writer, "Header");
-        probeAssetHeader(obj, m_version, hostname(), instanceId, 0, bufferSize, assetCount,
+        probeAssetHeader(obj, m_version, m_senderName, instanceId, 0, bufferSize, assetCount,
                          *m_schemaVersion, m_modelChangeTime);
       }
       {
@@ -420,7 +404,7 @@ namespace mtconnect::printer {
       obj.AddPairs("jsonVersion", m_jsonVersion, "schemaVersion", *m_schemaVersion);
       {
         AutoJsonObject obj(writer, "Header");
-        streamHeader(obj, m_version, hostname(), instanceId, bufferSize, nextSeq, firstSeq, lastSeq,
+        streamHeader(obj, m_version, m_senderName, instanceId, bufferSize, nextSeq, firstSeq, lastSeq,
                      *m_schemaVersion, m_modelChangeTime);
       }
 

--- a/src/mtconnect/printer/json_printer.hpp
+++ b/src/mtconnect/printer/json_printer.hpp
@@ -52,7 +52,6 @@ namespace mtconnect::printer {
     uint32_t getJsonVersion() const { return m_jsonVersion; }
 
   protected:
-    const std::string &hostname() const;
     std::string m_version;
     std::string m_hostname;
     uint32_t m_jsonVersion;

--- a/src/mtconnect/printer/printer.hpp
+++ b/src/mtconnect/printer/printer.hpp
@@ -126,6 +126,14 @@ namespace mtconnect {
       /// @brief Get the schema version
       /// @return the schema version
       const auto &getSchemaVersion() const { return m_schemaVersion; }
+            
+      /// @brief sets the sener name for the header
+      /// @param name the name of the sender
+      void setSenderName(const std::string &s) { m_senderName = s; }
+      
+      /// @brief gets the sender name
+      /// @returns the name of the sender in the header
+      const auto &getSenderName() const { return m_senderName; }
 
       /// @brief Use the agent version to default the schema version
       void defaultSchemaVersion() const
@@ -142,6 +150,7 @@ namespace mtconnect {
       bool m_pretty;
       std::string m_modelChangeTime;
       std::optional<std::string> m_schemaVersion;
+      std::string m_senderName { "localhost" };
     };
   }  // namespace printer
 }  // namespace mtconnect

--- a/src/mtconnect/printer/xml_printer.cpp
+++ b/src/mtconnect/printer/xml_printer.cpp
@@ -634,15 +634,7 @@ namespace mtconnect::printer {
 
     addAttribute(writer, "creationTime", getCurrentTime(GMT));
 
-    static std::string sHostname;
-    if (sHostname.empty())
-    {
-      boost::system::error_code ec;
-      sHostname = boost::asio::ip::host_name(ec);
-      if (ec)
-        sHostname = "localhost";
-    }
-    addAttribute(writer, "sender", sHostname);
+    addAttribute(writer, "sender", m_senderName);
     addAttribute(writer, "instanceId", to_string(instanceId));
 
     char version[32] = {0};

--- a/test_package/agent_test.cpp
+++ b/test_package/agent_test.cpp
@@ -3023,3 +3023,22 @@ TEST_F(AgentTest, should_not_add_spaces_to_output)
     ASSERT_XML_PATH_EQUAL(doc, "//m:DeviceStream//m:Block", "");
   }
 }
+
+TEST_F(AgentTest, should_set_sender_from_config_in_XML_header)
+{
+  auto agent = m_agentTestHelper->createAgent("/samples/test_config.xml", 8, 4, "2.0", 4, false, true, {{configuration::Sender, "MachineXXX"s}});
+  ASSERT_TRUE(agent);
+  {
+    PARSE_XML_RESPONSE("/probe");
+    ASSERT_XML_PATH_EQUAL(doc, "//m:Header@sender", "MachineXXX");
+  }
+  
+  {
+    PARSE_XML_RESPONSE("/current");
+    ASSERT_XML_PATH_EQUAL(doc, "//m:Header@sender", "MachineXXX");
+  }
+
+  
+}
+
+

--- a/test_package/json_printer_asset_test.cpp
+++ b/test_package/json_printer_asset_test.cpp
@@ -94,6 +94,7 @@ protected:
 TEST_F(JsonPrinterAssetTest, AssetHeader)
 {
   AssetList asset;
+  m_printer->setSenderName("MachineXXX");
   auto doc = m_printer->printAssets(123, 1024, 10, asset);
   auto jdoc = json::parse(doc);
   auto it = jdoc.begin();
@@ -102,6 +103,7 @@ TEST_F(JsonPrinterAssetTest, AssetHeader)
   ASSERT_EQ(123, jdoc.at("/MTConnectAssets/Header/instanceId"_json_pointer).get<int32_t>());
   ASSERT_EQ(1024, jdoc.at("/MTConnectAssets/Header/assetBufferSize"_json_pointer).get<int32_t>());
   ASSERT_EQ(10, jdoc.at("/MTConnectAssets/Header/assetCount"_json_pointer).get<int32_t>());
+  ASSERT_EQ("MachineXXX", jdoc.at("/MTConnectAssets/Header/sender"_json_pointer).get<string>());
 }
 
 TEST_F(JsonPrinterAssetTest, CuttingTool)

--- a/test_package/json_printer_probe_test.cpp
+++ b/test_package/json_printer_probe_test.cpp
@@ -84,6 +84,7 @@ protected:
 
 TEST_F(JsonPrinterProbeTest, DeviceRootAndDescription)
 {
+  m_printer->setSenderName("MachineXXX");
   auto doc = m_printer->printProbe(123, 9999, 1, 1024, 10, m_devices);
   auto jdoc = json::parse(doc);
   auto it = jdoc.begin();
@@ -93,6 +94,8 @@ TEST_F(JsonPrinterProbeTest, DeviceRootAndDescription)
   ASSERT_EQ(9999, jdoc.at("/MTConnectDevices/Header/bufferSize"_json_pointer).get<int32_t>());
   ASSERT_EQ(1024, jdoc.at("/MTConnectDevices/Header/assetBufferSize"_json_pointer).get<int32_t>());
   ASSERT_EQ(10, jdoc.at("/MTConnectDevices/Header/assetCount"_json_pointer).get<int32_t>());
+  ASSERT_EQ("MachineXXX", jdoc.at("/MTConnectDevices/Header/sender"_json_pointer).get<string>());
+
 
   auto devices = jdoc.at("/MTConnectDevices/Devices"_json_pointer);
   ASSERT_EQ(2_S, devices.size());

--- a/test_package/json_printer_stream_test.cpp
+++ b/test_package/json_printer_stream_test.cpp
@@ -140,6 +140,7 @@ TEST_F(JsonPrinterStreamTest, StreamHeader)
   Checkpoint checkpoint;
   ObservationList list;
   checkpoint.getObservations(list);
+  m_printer->setSenderName("MachineXXX");
   auto doc = m_printer->printSample(123, 131072, 10254805, 10123733, 10123800, list);
   auto jdoc = json::parse(doc);
   auto it = jdoc.begin();
@@ -152,6 +153,7 @@ TEST_F(JsonPrinterStreamTest, StreamHeader)
             jdoc.at("/MTConnectStreams/Header/firstSequence"_json_pointer).get<uint64_t>());
   ASSERT_EQ(uint64_t(10123800),
             jdoc.at("/MTConnectStreams/Header/lastSequence"_json_pointer).get<uint64_t>());
+  ASSERT_EQ("MachineXXX", jdoc.at("/MTConnectStreams/Header/sender"_json_pointer).get<string>());
 }
 
 TEST_F(JsonPrinterStreamTest, DeviceStream)

--- a/test_package/xml_printer_test.cpp
+++ b/test_package/xml_printer_test.cpp
@@ -105,16 +105,19 @@ ObservationPtr XmlPrinterTest::addEventToCheckpoint(Checkpoint &checkpoint, cons
 
 TEST_F(XmlPrinterTest, PrintError)
 {
+  m_printer->setSenderName("MachineXXX");
   PARSE_XML(m_printer->printError(123, 9999, 1, "ERROR_CODE", "ERROR TEXT!"));
 
   ASSERT_XML_PATH_EQUAL(doc, "//m:Header@instanceId", "123");
   ASSERT_XML_PATH_EQUAL(doc, "//m:Header@bufferSize", "9999");
+  ASSERT_XML_PATH_EQUAL(doc, "//m:Header@sender", "MachineXXX");
   ASSERT_XML_PATH_EQUAL(doc, "//m:Error@errorCode", "ERROR_CODE");
   ASSERT_XML_PATH_EQUAL(doc, "//m:Error", "ERROR TEXT!");
 }
 
 TEST_F(XmlPrinterTest, PrintProbe)
 {
+  m_printer->setSenderName("MachineXXX");
   PARSE_XML(m_printer->printProbe(123, 9999, 1, 1024, 10, m_devices));
 
   ASSERT_XML_PATH_EQUAL(doc, "//m:Header@instanceId", "123");
@@ -122,6 +125,7 @@ TEST_F(XmlPrinterTest, PrintProbe)
   ASSERT_XML_PATH_EQUAL(doc, "//m:Header@assetBufferSize", "1024");
   ASSERT_XML_PATH_EQUAL(doc, "//m:Header@assetCount", "10");
   ASSERT_XML_PATH_EQUAL(doc, "//m:Header@deviceModelChangeTime", 0);
+  ASSERT_XML_PATH_EQUAL(doc, "//m:Header@sender", "MachineXXX");
 
   // Check Description
   ASSERT_XML_PATH_EQUAL(doc, "//m:Description@manufacturer", "NIST");


### PR DESCRIPTION
Added `Sender = ...` configuration option. Sets value in the `<Header ...>` element of the docuemnts.