### PR TITLE
Fix for issue 420

### DIFF
--- a/src/mtconnect/configuration/agent_config.cpp
+++ b/src/mtconnect/configuration/agent_config.cpp
@@ -315,7 +315,7 @@ namespace mtconnect::configuration {
       LOG(warning) << "... File changed at: " << put_time(localtime(&t), "%F %T");
     }
 
-    auto delta = min(now - cfgTime, now - devTime);
+    auto delta = duration_cast<seconds>(min(now - cfgTime, now - devTime));
     if (delta < m_monitorDelay)
     {
       LOG(warning) << "... Waiting " << int32_t((m_monitorDelay - delta).count()) << " seconds";

--- a/test_package/agent_test.cpp
+++ b/test_package/agent_test.cpp
@@ -2680,7 +2680,8 @@ TEST_F(AgentTest, should_stream_data_with_interval)
     ASSERT_FALSE(m_agentTestHelper->m_session->m_chunkBody.empty());
     PARSE_XML_CHUNK();
 
-    EXPECT_GT(slop, delta) << "delta " << delta.count() << " < delay " << slop.count();
+    auto deltaMS = duration_cast<milliseconds>(delta);
+    EXPECT_GT(slop, deltaMS) << "delta " << deltaMS.count() << " < delay " << slop.count();
   }
 }
 


### PR DESCRIPTION
This PR should fix #420
AgentConfiguration::monitorThread message reports wrong number of seconds