### PR TITLE
Issue-423: Crash when editing device dataitem in DeviceModel

### DIFF
--- a/src/mtconnect/buffer/checkpoint.hpp
+++ b/src/mtconnect/buffer/checkpoint.hpp
@@ -174,9 +174,17 @@ namespace mtconnect::buffer {
     /// @param[in] diMap the map of data ids to data item pointers
     void updateDataItems(std::unordered_map<std::string, WeakDataItemPtr> &diMap)
     {
-      for (auto &o : m_observations)
+      auto iter = m_observations.begin();
+      while( iter != m_observations.end() )
       {
-        o.second->updateDataItem(diMap);
+        auto item = *iter;
+        if( item.second->isOrphan() ) {
+          iter = m_observations.erase(iter);
+        }
+        else {
+          item.second->updateDataItem(diMap);
+          iter++;
+        }
       }
     }
 

--- a/src/mtconnect/buffer/circular_buffer.hpp
+++ b/src/mtconnect/buffer/circular_buffer.hpp
@@ -85,26 +85,12 @@ namespace mtconnect::buffer {
     /// @param diMap the map of data item ids to new data item entities
     void updateDataItems(std::unordered_map<std::string, WeakDataItemPtr> &diMap)
     {
-      std::vector<boost::circular_buffer<observation::ObservationPtr>::iterator> orphanBufferItems;
-
-      auto iter = m_slidingBuffer.begin();
-      while( iter != m_slidingBuffer.end() )
+      for (auto &o : m_slidingBuffer)
       {
-        observation::ObservationPtr o = *iter;
         if( o->isOrphan() ) {
-          orphanBufferItems.push_back(iter);
+          continue;
         }
-        else {
-          o->updateDataItem(diMap);
-        }
-        iter++;
-      }
-
-      // remove orphans from the slidingBuffer
-      while(!orphanBufferItems.empty()) {
-        auto orphanIterIter = orphanBufferItems.back();
-        m_slidingBuffer.erase(orphanIterIter);
-        orphanBufferItems.pop_back();
+        o->updateDataItem(diMap);        
       }
 
       // checkpoints will remove orphans from its observations


### PR DESCRIPTION
#423 

Updated Checkpoint::updateDataItems() to remove orphans from observations map. Updated CircularBuffer::updateDataItems() to remove orphans from m_slidingBuffer