### PR TITLE
419 UUID unavailable when changed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 set(AGENT_VERSION_MAJOR 2)
 set(AGENT_VERSION_MINOR 3)
 set(AGENT_VERSION_PATCH 0)
-set(AGENT_VERSION_BUILD 5)
+set(AGENT_VERSION_BUILD 6)
 set(AGENT_VERSION_RC "")
 
 # This minimum version is to support Visual Studio 2019 and C++ feature checking and FetchContent

--- a/src/mtconnect/source/adapter/shdr/shdr_adapter.cpp
+++ b/src/mtconnect/source/adapter/shdr/shdr_adapter.cpp
@@ -227,9 +227,7 @@ namespace mtconnect::source::adapter::shdr {
 
         if (command == "uuid")
         {
-          DevicePtr dp;
-          if (auto dev = GetOption<string>(m_options, configuration::Device);
-              dev && (dp = m_pipeline.getContext()->m_contract->findDevice(*dev)))
+          if (auto dp = m_pipeline.getContext()->m_contract->findDevice(value); dp)
           {
             if (!dp->preserveUuid())
             {


### PR DESCRIPTION
* Fixed issue when preserve uuiid was false and device changed. Was not rebuilding pipeline.
* Version 2.3.0.6