### PR TITLE
Added support for sample data sets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 set(AGENT_VERSION_MAJOR 2)
 set(AGENT_VERSION_MINOR 4)
 set(AGENT_VERSION_PATCH 0)
-set(AGENT_VERSION_BUILD 6)
+set(AGENT_VERSION_BUILD 7)
 set(AGENT_VERSION_RC "")
 
 # This minimum version is to support Visual Studio 2019 and C++ feature checking and FetchContent

--- a/src/mtconnect/pipeline/shdr_token_mapper.cpp
+++ b/src/mtconnect/pipeline/shdr_token_mapper.cpp
@@ -243,7 +243,12 @@ namespace mtconnect {
       entity::Requirements *reqs {nullptr};
 
       // Extract the remaining tokens
-      if (dataItem->isSample())
+      if ((dataItem->isDataSet() || dataItem->isTable()) &&
+          (dataItem->isSample() || dataItem->isEvent()))
+      {
+        reqs = &s_dataSet;
+      }
+      else if (dataItem->isSample())
       {
         if (dataItem->isTimeSeries())
           reqs = &s_timeseries;
@@ -258,8 +263,6 @@ namespace mtconnect {
           reqs = &s_message;
         else if (dataItem->isAlarm())
           reqs = &s_alarm;
-        else if (dataItem->isDataSet() || dataItem->isTable())
-          reqs = &s_dataSet;
         else if (dataItem->isAssetChanged() || dataItem->isAssetRemoved())
           reqs = &s_assetEvent;
         else


### PR DESCRIPTION
Data sets used only support event categories. Samples can also have Data Set and Table representations as long as all the values are doubles.