### PR TITLE
Validation of timestamps and validation of values for SHDR and JSON pipeline conversions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,6 +672,10 @@ Configuration Parameters
 
     *Default*: `false`
     
+* `ValidateTimestamps` - Verify time is always progressing forward for each data item and correct if not.
+
+    *Default*: `false`
+
 * `Validation` - Turns on validation of model components and observations
 
     *Default*: `false`

--- a/README.md
+++ b/README.md
@@ -672,7 +672,7 @@ Configuration Parameters
 
     *Default*: `false`
     
-* `ValidateTimestamps` - Verify time is always progressing forward for each data item and correct if not.
+* `CorrectTimestamps` - Verify time is always progressing forward for each data item and correct if not.
 
     *Default*: `false`
 

--- a/agent_lib/CMakeLists.txt
+++ b/agent_lib/CMakeLists.txt
@@ -189,6 +189,7 @@ set(AGENT_SOURCES
         "${SOURCE_DIR}/pipeline/topic_mapper.hpp"
         "${SOURCE_DIR}/pipeline/transform.hpp"
         "${SOURCE_DIR}/pipeline/upcase_value.hpp"
+        "${SOURCE_DIR}/pipeline/validate_timestamp.hpp"       
         "${SOURCE_DIR}/pipeline/validator.hpp"       
    
 # src/pipeline SOURCE_FILES_ONLY

--- a/agent_lib/CMakeLists.txt
+++ b/agent_lib/CMakeLists.txt
@@ -189,7 +189,7 @@ set(AGENT_SOURCES
         "${SOURCE_DIR}/pipeline/topic_mapper.hpp"
         "${SOURCE_DIR}/pipeline/transform.hpp"
         "${SOURCE_DIR}/pipeline/upcase_value.hpp"
-        "${SOURCE_DIR}/pipeline/validate_timestamp.hpp"       
+        "${SOURCE_DIR}/pipeline/correct_timestamp.hpp"       
         "${SOURCE_DIR}/pipeline/validator.hpp"       
    
 # src/pipeline SOURCE_FILES_ONLY

--- a/src/mtconnect/agent.hpp
+++ b/src/mtconnect/agent.hpp
@@ -213,6 +213,10 @@ namespace mtconnect {
     /// @brief Get the MTConnect schema version the agent is supporting
     /// @return The MTConnect schema version as a string
     const auto &getSchemaVersion() const { return m_schemaVersion; }
+    
+    /// @brief Get the validation state of the agent
+    /// @returns the validation state of the agent
+    bool hasValidation() const { return m_validation; }
 
     /// @brief Get the integer schema version based on configuration.
     /// @returns the schema version as an integer [major * 100 + minor] as a 32bit integer.
@@ -589,6 +593,7 @@ namespace mtconnect {
       }
     }
     int32_t getSchemaVersion() const override { return m_agent->getIntSchemaVersion(); }
+    bool hasValidation() const override { return m_agent->hasValidation(); }
     void deliverObservation(observation::ObservationPtr obs) override
     {
       m_agent->receiveObservation(obs);

--- a/src/mtconnect/configuration/agent_config.cpp
+++ b/src/mtconnect/configuration/agent_config.cpp
@@ -831,7 +831,7 @@ namespace mtconnect::configuration {
                 {configuration::SuppressIPAddress, false},
                 {configuration::AllowPutFrom, ""s},
                 {configuration::Validation, false},
-                {configuration::ValidateTimestamps, false}});
+                {configuration::CorrectTimestamps, false}});
 
     m_workerThreadCount = *GetOption<int>(options, configuration::WorkerThreads);
     m_monitorFiles = *GetOption<bool>(options, configuration::MonitorConfigFiles);

--- a/src/mtconnect/configuration/agent_config.cpp
+++ b/src/mtconnect/configuration/agent_config.cpp
@@ -830,7 +830,8 @@ namespace mtconnect::configuration {
                 {configuration::TlsClientCAs, ""s},
                 {configuration::SuppressIPAddress, false},
                 {configuration::AllowPutFrom, ""s},
-                {configuration::Validation, false}});
+                {configuration::Validation, false},
+                {configuration::ValidateTimestamps, false}});
 
     m_workerThreadCount = *GetOption<int>(options, configuration::WorkerThreads);
     m_monitorFiles = *GetOption<bool>(options, configuration::MonitorConfigFiles);

--- a/src/mtconnect/configuration/config_options.hpp
+++ b/src/mtconnect/configuration/config_options.hpp
@@ -77,6 +77,7 @@ namespace mtconnect {
     DECLARE_CONFIGURATION(EnableSourceDeviceModels);
     DECLARE_CONFIGURATION(WorkerThreads);
     DECLARE_CONFIGURATION(Validation);
+    DECLARE_CONFIGURATION(ValidateTimestamps);
     ///@}
 
     /// @name MQTT Configuration

--- a/src/mtconnect/configuration/config_options.hpp
+++ b/src/mtconnect/configuration/config_options.hpp
@@ -77,7 +77,7 @@ namespace mtconnect {
     DECLARE_CONFIGURATION(EnableSourceDeviceModels);
     DECLARE_CONFIGURATION(WorkerThreads);
     DECLARE_CONFIGURATION(Validation);
-    DECLARE_CONFIGURATION(ValidateTimestamps);
+    DECLARE_CONFIGURATION(CorrectTimestamps);
     ///@}
 
     /// @name MQTT Configuration

--- a/src/mtconnect/entity/entity.hpp
+++ b/src/mtconnect/entity/entity.hpp
@@ -95,7 +95,12 @@ namespace mtconnect {
       /// @param props entity properties
       Entity(const std::string &name, const Properties &props) : m_name(name), m_properties(props)
       {}
-      Entity(const Entity &entity) = default;
+      Entity(const Entity &entity)
+      : m_name(entity.m_name), m_properties(entity.m_properties), m_order(entity.m_order)
+      {
+        if (entity.m_attributes)
+          setAttributes(*entity.m_attributes);
+      }
       virtual ~Entity() {}
 
       /// @brief Get a shared pointer
@@ -348,10 +353,21 @@ namespace mtconnect {
       auto erase(Properties::iterator &it) { return m_properties.erase(it); }
       /// @brief tells the entity which properties are attributes for XML generation
       /// @param[in] a the attributes
-      void setAttributes(AttributeSet a) { m_attributes = a; }
+      void setAttributes(AttributeSet a)
+      {
+        std::unique_ptr<AttributeSet> set(new AttributeSet(a));
+        m_attributes.swap(set);
+      }
       /// @brief get the attributes for XML generation
       /// @return attribute set
-      const auto &getAttributes() const { return m_attributes; }
+      const auto &getAttributes() const
+      {
+        static AttributeSet empty;
+        if (m_attributes)
+          return *m_attributes;
+        else
+          return empty;
+      }
 
       /// @brief compare two entities for equality
       /// @param other the other entity
@@ -436,7 +452,7 @@ namespace mtconnect {
       QName m_name;
       Properties m_properties;
       OrderMapPtr m_order;
-      AttributeSet m_attributes;
+      std::unique_ptr<AttributeSet> m_attributes;
     };
 
     /// @brief variant visitor to compare two entity parameter values for equality

--- a/src/mtconnect/entity/entity.hpp
+++ b/src/mtconnect/entity/entity.hpp
@@ -453,6 +453,7 @@ namespace mtconnect {
       Properties m_properties;
       OrderMapPtr m_order;
       std::unique_ptr<AttributeSet> m_attributes;
+      std::unique_ptr<ErrorList> m_errors;
     };
 
     /// @brief variant visitor to compare two entity parameter values for equality

--- a/src/mtconnect/pipeline/correct_timestamp.hpp
+++ b/src/mtconnect/pipeline/correct_timestamp.hpp
@@ -1,0 +1,86 @@
+//
+// Copyright Copyright 2009-2024, AMT – The Association For Manufacturing Technology (“AMT”)
+// All rights reserved.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+
+#pragma once
+
+#include "mtconnect/config.hpp"
+#include "transform.hpp"
+
+namespace mtconnect::pipeline {
+  /// @brief Filter duplicates
+  class AGENT_LIB_API CorrectTimestamp : public Transform
+  {
+  protected:
+    struct State : TransformState
+    {
+      std::unordered_map<std::string, Timestamp> m_timestamps;
+    };
+
+  public:
+    CorrectTimestamp(const CorrectTimestamp &) = default;
+    /// @brief Create a duplicate filter with shared state from the context
+    /// @param context the context
+    CorrectTimestamp(PipelineContextPtr context)
+      : Transform("ValidateTimestamp"),
+        m_context(context),
+        m_state(context->getSharedState<State>(m_name))
+    {
+      m_guard = TypeGuard<observation::Observation>(RUN);
+    }
+    ~CorrectTimestamp() override = default;
+
+    /// @brief check if the entity is a duplicate
+    /// @param[in] entity the entity to check
+    /// @return the result of the transform if not a duplicate or an empty entity
+    entity::EntityPtr operator()(entity::EntityPtr &&entity) override
+    {
+      using namespace observation;
+
+      auto obs = std::dynamic_pointer_cast<Observation>(entity);
+      if (obs->isOrphan())
+        return entity::EntityPtr();
+
+      auto di = obs->getDataItem();
+      auto &id = di->getId();
+      auto ts = obs->getTimestamp();
+
+      std::lock_guard<TransformState> guard(*m_state);
+
+      auto last = m_state->m_timestamps.find(id);
+      if (last != m_state->m_timestamps.end())
+      {
+        if (ts < last->second)
+        {
+          LOG(debug) << "Observation for data item " << id << " has timestamp " << format(ts)
+                     << " thats is before " << format(last->second);
+
+          // Set the timestamp to now.
+          ts = std::chrono::system_clock::now();
+          obs->setTimestamp(ts);
+        }
+      }
+
+      m_state->m_timestamps.emplace(id, ts);
+
+      return obs;
+    }
+
+  protected:
+    PipelineContextPtr m_context;
+    std::shared_ptr<State> m_state;
+  };
+}  // namespace mtconnect::pipeline

--- a/src/mtconnect/pipeline/duplicate_filter.hpp
+++ b/src/mtconnect/pipeline/duplicate_filter.hpp
@@ -25,12 +25,6 @@ namespace mtconnect::pipeline {
   class AGENT_LIB_API DuplicateFilter : public Transform
   {
   public:
-    /// @brief Shared states to check for duplicates
-    struct State : TransformState
-    {
-      std::unordered_map<std::string, entity::Value> m_values;
-    };
-
     DuplicateFilter(const DuplicateFilter &) = default;
     /// @brief Create a duplicate filter with shared state from the context
     /// @param context the context

--- a/src/mtconnect/pipeline/json_mapper.cpp
+++ b/src/mtconnect/pipeline/json_mapper.cpp
@@ -134,14 +134,19 @@ namespace mtconnect::pipeline {
           {
             LOG(warning) << "Error while parsing json: " << e->what();
           }
+          
+          props.clear();
+          props["VALUE"] = "UNAVAILABLE"s;
+          if (m_pipelineContext->m_contract->hasValidation())
+            props["quality"] = "INVALID"s;
+          
+          obs = observation::Observation::make(dataItem, props, *m_timestamp, errors);
         }
-        else
-        {
-          if (m_source)
-            dataItem->setDataSource(*m_source);
-          m_entities.push_back(obs);
-          m_forward(std::move(obs));
-        }
+
+        if (m_source)
+          dataItem->setDataSource(*m_source);
+        m_entities.push_back(obs);
+        m_forward(std::move(obs));
       }
     }
 

--- a/src/mtconnect/pipeline/json_mapper.hpp
+++ b/src/mtconnect/pipeline/json_mapper.hpp
@@ -24,8 +24,6 @@
 #include "mtconnect/entity/entity.hpp"
 #include "mtconnect/observation/observation.hpp"
 #include "mtconnect/pipeline/timestamp_extractor.hpp"
-#include "shdr_tokenizer.hpp"
-#include "timestamp_extractor.hpp"
 #include "topic_mapper.hpp"
 #include "transform.hpp"
 

--- a/src/mtconnect/pipeline/pipeline_contract.hpp
+++ b/src/mtconnect/pipeline/pipeline_contract.hpp
@@ -76,6 +76,9 @@ namespace mtconnect {
       /// @brief get the current schema version as an integer
       /// @returns the schema version as an integer [major * 100 + minor] as a 32bit integer.
       virtual int32_t getSchemaVersion() const = 0;
+      /// @brief `true` if validation is turned on for the agent.
+      /// @returns the validation state for the pipeline
+      virtual bool hasValidation() const = 0;
       /// @brief iterate through all the data items calling `fun` for each
       /// @param[in] fun The function or lambda to call
       virtual void eachDataItem(EachDataItem fun) = 0;

--- a/src/mtconnect/pipeline/shdr_token_mapper.cpp
+++ b/src/mtconnect/pipeline/shdr_token_mapper.cpp
@@ -137,7 +137,7 @@ namespace mtconnect {
                                         const entity::Requirements &reqs,
                                         TokenList::const_iterator &token,
                                         const TokenList::const_iterator &end, ErrorList &errors,
-                                        int32_t schemaVersion)
+                                        int32_t schemaVersion, bool validation)
     {
       NAMED_SCOPE("zipProperties");
       Properties props;
@@ -168,6 +168,10 @@ namespace mtconnect {
         {
           LOG(warning) << "Cannot convert value for data item id '" << dataItem->getId()
                        << "': " << *token << " - " << e.what();
+          if (schemaVersion >= SCHEMA_VERSION(2, 5) && validation)
+          {
+            props.insert_or_assign("quality", "INVALID"s);
+          }
         }
       }
 
@@ -276,7 +280,8 @@ namespace mtconnect {
       if (reqs != nullptr)
       {
         auto obs = zipProperties(dataItem, timestamp, *reqs, token, end, errors,
-                                 m_contract->getSchemaVersion());
+                                 m_contract->getSchemaVersion(),
+                                 m_contract->hasValidation());
         if (dataItem->getConstantValue())
           return nullptr;
         if (obs && source)

--- a/src/mtconnect/source/adapter/adapter_pipeline.cpp
+++ b/src/mtconnect/source/adapter/adapter_pipeline.cpp
@@ -28,7 +28,7 @@
 #include "mtconnect/pipeline/timestamp_extractor.hpp"
 #include "mtconnect/pipeline/topic_mapper.hpp"
 #include "mtconnect/pipeline/upcase_value.hpp"
-#include "mtconnect/pipeline/validate_timestamp.hpp"
+#include "mtconnect/pipeline/correct_timestamp.hpp"
 #include "mtconnect/pipeline/validator.hpp"
 #include "mtconnect/source/adapter/adapter.hpp"
 
@@ -141,8 +141,8 @@ namespace mtconnect {
       if (IsOptionSet(m_options, configuration::ConversionRequired))
         next = next->bind(make_shared<ConvertSample>());
 
-      if (IsOptionSet(m_options, configuration::ValidateTimestamps))
-        next = next->bind(make_shared<ValidateTimestamp>(m_context));
+      if (IsOptionSet(m_options, configuration::CorrectTimestamps))
+        next = next->bind(make_shared<CorrectTimestamp>(m_context));
 
       // Validate Values
       if (IsOptionSet(m_options, configuration::Validation))

--- a/src/mtconnect/source/adapter/adapter_pipeline.cpp
+++ b/src/mtconnect/source/adapter/adapter_pipeline.cpp
@@ -28,6 +28,7 @@
 #include "mtconnect/pipeline/timestamp_extractor.hpp"
 #include "mtconnect/pipeline/topic_mapper.hpp"
 #include "mtconnect/pipeline/upcase_value.hpp"
+#include "mtconnect/pipeline/validate_timestamp.hpp"
 #include "mtconnect/pipeline/validator.hpp"
 #include "mtconnect/source/adapter/adapter.hpp"
 
@@ -139,6 +140,9 @@ namespace mtconnect {
       // Convert values
       if (IsOptionSet(m_options, configuration::ConversionRequired))
         next = next->bind(make_shared<ConvertSample>());
+
+      if (IsOptionSet(m_options, configuration::ValidateTimestamps))
+        next = next->bind(make_shared<ValidateTimestamp>(m_context));
 
       // Validate Values
       if (IsOptionSet(m_options, configuration::Validation))

--- a/src/mtconnect/source/adapter/mqtt/mqtt_adapter.cpp
+++ b/src/mtconnect/source/adapter/mqtt/mqtt_adapter.cpp
@@ -82,13 +82,13 @@ namespace mtconnect {
                            {configuration::RealTime, false},
                            {configuration::RelativeTime, false}});
       loadTopics(block, m_options);
-      
+
       if (!HasOption(m_options, configuration::MqttHost) &&
           HasOption(m_options, configuration::Host))
       {
         m_options[configuration::MqttHost] = m_options[configuration::Host];
       }
-      
+
       if (!HasOption(m_options, configuration::MqttPort))
       {
         if (HasOption(m_options, configuration::Port))
@@ -100,7 +100,7 @@ namespace mtconnect {
           m_options[configuration::MqttPort] = 1883;
         }
       }
-      
+
       m_handler = m_pipeline.makeHandler();
       auto clientHandler = make_unique<ClientHandler>();
 
@@ -147,9 +147,9 @@ namespace mtconnect {
         m_client = make_shared<mtconnect::mqtt_client::MqttTcpClient>(m_ioContext, m_options,
                                                                       std::move(clientHandler));
       }
-      
+
       m_name = m_client->getUrl();
-            
+
       if (auto ident = GetOption<string>(m_options, configuration::AdapterIdentity))
       {
         m_identity = *ident;
@@ -157,7 +157,7 @@ namespace mtconnect {
       else
       {
         stringstream identity;
-        
+
         identity << m_name;
         auto topics = GetOption<StringList>(m_options, configuration::Topics);
         if (topics)
@@ -170,7 +170,7 @@ namespace mtconnect {
         sha1.process_bytes(identity.str().c_str(), identity.str().length());
         boost::uuids::detail::sha1::digest_type digest;
         sha1.get_digest(digest);
-        
+
         identity.str("");
         identity << std::hex << digest[0] << digest[1] << digest[2];
         m_identity = string("_") + (identity.str()).substr(0, 10);

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -281,7 +281,7 @@ add_agent_test(mtconnect_xml_transform FALSE pipeline)
 add_agent_test(response_document FALSE pipeline)
 add_agent_test(json_mapping FALSE pipeline)
 add_agent_test(observation_validation TRUE pipeline)
-add_agent_test(validate_timestamp TRUE pipeline)
+add_agent_test(correct_timestamp TRUE pipeline)
 
 add_agent_test(agent TRUE core)
 add_agent_test(globals FALSE core)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -281,6 +281,7 @@ add_agent_test(mtconnect_xml_transform FALSE pipeline)
 add_agent_test(response_document FALSE pipeline)
 add_agent_test(json_mapping FALSE pipeline)
 add_agent_test(observation_validation TRUE pipeline)
+add_agent_test(validate_timestamp TRUE pipeline)
 
 add_agent_test(agent TRUE core)
 add_agent_test(globals FALSE core)

--- a/test_package/correct_timestamp_test.cpp
+++ b/test_package/correct_timestamp_test.cpp
@@ -1,0 +1,166 @@
+//
+// Copyright Copyright 2009-2024, AMT – The Association For Manufacturing Technology (“AMT”)
+// All rights reserved.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+
+// Ensure that gtest is the first header otherwise Windows raises an error
+#include <gtest/gtest.h>
+// Keep this comment to keep gtest.h above. (clang-format off/on is not working here!)
+
+#include <chrono>
+
+#include "mtconnect/buffer/checkpoint.hpp"
+#include "mtconnect/observation/observation.hpp"
+#include "mtconnect/pipeline/deliver.hpp"
+#include "mtconnect/pipeline/delta_filter.hpp"
+#include "mtconnect/pipeline/period_filter.hpp"
+#include "mtconnect/pipeline/pipeline.hpp"
+#include "mtconnect/pipeline/shdr_token_mapper.hpp"
+#include "mtconnect/pipeline/correct_timestamp.hpp"
+
+using namespace mtconnect;
+using namespace mtconnect::pipeline;
+using namespace mtconnect::observation;
+using namespace mtconnect::asset;
+using namespace device_model;
+using namespace data_item;
+using namespace entity;
+using namespace std;
+using namespace std::literals;
+using namespace std::chrono_literals;
+
+// main
+int main(int argc, char *argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+
+class MockPipelineContract : public PipelineContract
+{
+public:
+  MockPipelineContract(std::map<string, DataItemPtr> &items) : m_dataItems(items) {}
+  DevicePtr findDevice(const std::string &device) override { return nullptr; }
+  DataItemPtr findDataItem(const std::string &device, const std::string &name) override
+  {
+    return m_dataItems[name];
+  }
+  void eachDataItem(EachDataItem fun) override {}
+  void deliverObservation(observation::ObservationPtr obs) override {}
+  void deliverAsset(AssetPtr) override {}
+  void deliverDevices(std::list<DevicePtr>) override {}
+  void deliverDevice(DevicePtr) override {}
+  void deliverAssetCommand(entity::EntityPtr) override {}
+  int32_t getSchemaVersion() const override { return IntDefaultSchemaVersion(); }
+  void deliverCommand(entity::EntityPtr) override {}
+  void deliverConnectStatus(entity::EntityPtr, const StringList &, bool) override {}
+  void sourceFailed(const std::string &id) override {}
+  const ObservationPtr checkDuplicate(const ObservationPtr &obs) const override { return nullptr; }
+
+  std::map<string, DataItemPtr> &m_dataItems;
+};
+
+class ValidateTimestampTest : public testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    ErrorList errors;
+    m_component = Component::make("Linear", {{"id", "x"s}, {"name", "X"s}}, errors);
+
+    m_context = make_shared<PipelineContext>();
+    m_context->m_contract = make_unique<MockPipelineContract>(m_dataItems);
+    m_mapper = make_shared<ShdrTokenMapper>(m_context);
+    m_mapper->bind(make_shared<NullTransform>(TypeGuard<Observations>(RUN)));
+  }
+
+  void TearDown() override { m_dataItems.clear(); }
+
+  DataItemPtr makeDataItem(Properties attributes)
+  {
+    ErrorList errors;
+    auto di = DataItem::make(attributes, errors);
+    m_dataItems.emplace(di->getId(), di);
+    m_component->addDataItem(di, errors);
+
+    return di;
+  }
+
+  const EntityPtr observe(TokenList tokens, Timestamp now)
+  {
+    auto ts = make_shared<Timestamped>();
+    ts->m_tokens = tokens;
+    ts->m_timestamp = now;
+    ts->setProperty("timestamp", ts->m_timestamp);
+
+    return (*m_mapper)(ts);
+  }
+
+  shared_ptr<ShdrTokenMapper> m_mapper;
+  std::map<string, DataItemPtr> m_dataItems;
+  shared_ptr<PipelineContext> m_context;
+  ComponentPtr m_component;
+};
+
+TEST_F(ValidateTimestampTest, should_not_change_timestamp_if_time_is_moving_forward)
+{
+  makeDataItem({{"id", "a"s}, {"type", "EXECUTION"s}, {"category", "EVENT"s}});
+
+  auto filter = make_shared<CorrectTimestamp>(m_context);
+  m_mapper->bind(filter);
+  filter->bind(make_shared<DeliverObservation>(m_context));
+
+  auto now = chrono::system_clock::now();
+
+  auto os1 = observe({"a", "READY"}, now);
+  auto list1 = os1->getValue<EntityList>();
+  ASSERT_EQ(1, list1.size());
+
+  auto obs1 = dynamic_pointer_cast<Observation>(list1.front());
+  ASSERT_EQ(now, obs1->getTimestamp());
+
+  auto os2 = observe({"a", "ACTIVE"}, now + 1s);
+  auto list2 = os2->getValue<EntityList>();
+  ASSERT_EQ(1, list2.size());
+
+  auto obs2 = dynamic_pointer_cast<Observation>(list2.front());
+  ASSERT_EQ(now + 1s, obs2->getTimestamp());
+}
+
+TEST_F(ValidateTimestampTest, should_change_timestamp_if_time_is_moving_backward)
+{
+  makeDataItem({{"id", "a"s}, {"type", "EXECUTION"s}, {"category", "EVENT"s}});
+
+  auto filter = make_shared<CorrectTimestamp>(m_context);
+  m_mapper->bind(filter);
+  filter->bind(make_shared<DeliverObservation>(m_context));
+
+  auto now = chrono::system_clock::now();
+
+  auto os1 = observe({"a", "READY"}, now);
+  auto list1 = os1->getValue<EntityList>();
+  ASSERT_EQ(1, list1.size());
+
+  auto obs1 = dynamic_pointer_cast<Observation>(list1.front());
+  ASSERT_EQ(now, obs1->getTimestamp());
+
+  auto os2 = observe({"a", "ACTIVE"}, now - 1s);
+  auto list2 = os2->getValue<EntityList>();
+  ASSERT_EQ(1, list2.size());
+
+  auto obs2 = dynamic_pointer_cast<Observation>(list2.front());
+  ASSERT_NE(now - 1s, obs2->getTimestamp());
+  ASSERT_LE(now, obs2->getTimestamp());
+}

--- a/test_package/mqtt_adapter_test.cpp
+++ b/test_package/mqtt_adapter_test.cpp
@@ -51,9 +51,7 @@ int main(int argc, char *argv[])
 class MockPipelineContract : public PipelineContract
 {
 public:
-  MockPipelineContract(int32_t schemaVersion)
-  : m_schemaVersion(schemaVersion)
-  {}
+  MockPipelineContract(int32_t schemaVersion) : m_schemaVersion(schemaVersion) {}
   DevicePtr findDevice(const std::string &) override { return nullptr; }
   DataItemPtr findDataItem(const std::string &device, const std::string &name) override
   {
@@ -70,7 +68,7 @@ public:
   void deliverConnectStatus(entity::EntityPtr, const StringList &, bool) override {}
   void sourceFailed(const std::string &id) override {}
   const ObservationPtr checkDuplicate(const ObservationPtr &obs) const override { return obs; }
-  
+
   int32_t m_schemaVersion;
 };
 
@@ -87,10 +85,10 @@ TEST_F(MqttAdapterTest, should_create_a_unique_id_based_on_topic)
   asio::io_context ioc;
   asio::io_context::strand strand(ioc);
   ConfigOptions options {{configuration::Url, "mqtt://mybroker.com:1883"s},
-    {configuration::Host, "mybroker.com"s},
-    {configuration::Port, 1883},
-    {configuration::Protocol, "mqtt"s},
-    {configuration::Topics, StringList {"pipeline/#"s}}};
+                         {configuration::Host, "mybroker.com"s},
+                         {configuration::Port, 1883},
+                         {configuration::Protocol, "mqtt"s},
+                         {configuration::Topics, StringList {"pipeline/#"s}}};
   boost::property_tree::ptree tree;
   pipeline::PipelineContextPtr context = make_shared<pipeline::PipelineContext>();
   context->m_contract = make_unique<MockPipelineContract>(SCHEMA_VERSION(2, 5));
@@ -105,18 +103,18 @@ TEST_F(MqttAdapterTest, should_change_if_topics_change)
   asio::io_context ioc;
   asio::io_context::strand strand(ioc);
   ConfigOptions options {{configuration::Url, "mqtt://mybroker.com:1883"s},
-    {configuration::Host, "mybroker.com"s},
-    {configuration::Port, 1883},
-    {configuration::Protocol, "mqtt"s},
-    {configuration::Topics, StringList {"pipeline/#"s}}};
+                         {configuration::Host, "mybroker.com"s},
+                         {configuration::Port, 1883},
+                         {configuration::Protocol, "mqtt"s},
+                         {configuration::Topics, StringList {"pipeline/#"s}}};
   boost::property_tree::ptree tree;
   pipeline::PipelineContextPtr context = make_shared<pipeline::PipelineContext>();
   context->m_contract = make_unique<MockPipelineContract>(SCHEMA_VERSION(2, 5));
   auto adapter = make_unique<MqttAdapter>(ioc, context, options, tree);
-  
+
   ASSERT_EQ("mqtt://mybroker.com:1883/", adapter->getName());
   ASSERT_EQ("_89c11f795e", adapter->getIdentity());
-  
+
   options[configuration::Topics] = StringList {"pipline/#"s, "topic/"s};
   adapter = make_unique<MqttAdapter>(ioc, context, options, tree);
 
@@ -128,21 +126,21 @@ TEST_F(MqttAdapterTest, should_change_if_port_changes)
   asio::io_context ioc;
   asio::io_context::strand strand(ioc);
   ConfigOptions options {{configuration::Url, "mqtt://mybroker.com:1883"s},
-    {configuration::Host, "mybroker.com"s},
-    {configuration::Port, 1883},
-    {configuration::Protocol, "mqtt"s},
-    {configuration::Topics, StringList {"pipeline/#"s}}};
+                         {configuration::Host, "mybroker.com"s},
+                         {configuration::Port, 1883},
+                         {configuration::Protocol, "mqtt"s},
+                         {configuration::Topics, StringList {"pipeline/#"s}}};
   boost::property_tree::ptree tree;
   pipeline::PipelineContextPtr context = make_shared<pipeline::PipelineContext>();
   context->m_contract = make_unique<MockPipelineContract>(SCHEMA_VERSION(2, 5));
   auto adapter = make_unique<MqttAdapter>(ioc, context, options, tree);
-  
+
   ASSERT_EQ("mqtt://mybroker.com:1883/", adapter->getName());
   ASSERT_EQ("_89c11f795e", adapter->getIdentity());
-  
+
   options[configuration::Port] = 1882;
   adapter = make_unique<MqttAdapter>(ioc, context, options, tree);
-  
+
   ASSERT_EQ("mqtt://mybroker.com:1882/", adapter->getName());
   ASSERT_EQ("_7042e8f45e", adapter->getIdentity());
 }
@@ -152,21 +150,21 @@ TEST_F(MqttAdapterTest, should_change_if_host_changes)
   asio::io_context ioc;
   asio::io_context::strand strand(ioc);
   ConfigOptions options {{configuration::Url, "mqtt://mybroker.com:1883"s},
-    {configuration::Host, "mybroker.com"s},
-    {configuration::Port, 1883},
-    {configuration::Protocol, "mqtt"s},
-    {configuration::Topics, StringList {"pipeline/#"s}}};
+                         {configuration::Host, "mybroker.com"s},
+                         {configuration::Port, 1883},
+                         {configuration::Protocol, "mqtt"s},
+                         {configuration::Topics, StringList {"pipeline/#"s}}};
   boost::property_tree::ptree tree;
   pipeline::PipelineContextPtr context = make_shared<pipeline::PipelineContext>();
   context->m_contract = make_unique<MockPipelineContract>(SCHEMA_VERSION(2, 5));
   auto adapter = make_unique<MqttAdapter>(ioc, context, options, tree);
-  
+
   ASSERT_EQ("mqtt://mybroker.com:1883/", adapter->getName());
   ASSERT_EQ("_89c11f795e", adapter->getIdentity());
-  
+
   options[configuration::Host] = "localhost"s;
   adapter = make_unique<MqttAdapter>(ioc, context, options, tree);
-  
+
   ASSERT_EQ("mqtt://localhost:1883/", adapter->getName());
   ASSERT_EQ("_4cd2e64d4e", adapter->getIdentity());
 }
@@ -176,16 +174,16 @@ TEST_F(MqttAdapterTest, should_be_able_to_set_adapter_identity)
   asio::io_context ioc;
   asio::io_context::strand strand(ioc);
   ConfigOptions options {{configuration::Url, "mqtt://mybroker.com:1883"s},
-    {configuration::Host, "mybroker.com"s},
-    {configuration::Port, 1883},
-    {configuration::Protocol, "mqtt"s},
-    {configuration::AdapterIdentity, "MyIdentity"s},
-    {configuration::Topics, StringList {"pipeline/#"s}}};
+                         {configuration::Host, "mybroker.com"s},
+                         {configuration::Port, 1883},
+                         {configuration::Protocol, "mqtt"s},
+                         {configuration::AdapterIdentity, "MyIdentity"s},
+                         {configuration::Topics, StringList {"pipeline/#"s}}};
   boost::property_tree::ptree tree;
   pipeline::PipelineContextPtr context = make_shared<pipeline::PipelineContext>();
   context->m_contract = make_unique<MockPipelineContract>(SCHEMA_VERSION(2, 5));
   auto adapter = make_unique<MqttAdapter>(ioc, context, options, tree);
-  
+
   ASSERT_EQ("mqtt://mybroker.com:1883/", adapter->getName());
   ASSERT_EQ("MyIdentity", adapter->getIdentity());
 }

--- a/test_package/observation_validation_test.cpp
+++ b/test_package/observation_validation_test.cpp
@@ -29,6 +29,9 @@
 #include "mtconnect/entity/entity.hpp"
 #include "mtconnect/observation/observation.hpp"
 #include "mtconnect/pipeline/validator.hpp"
+#include "mtconnect/pipeline/shdr_token_mapper.hpp"
+#include "mtconnect/pipeline/timestamp_extractor.hpp"
+#include "mtconnect/pipeline/json_mapper.hpp"
 
 using namespace mtconnect;
 using namespace mtconnect::pipeline;
@@ -49,11 +52,11 @@ int main(int argc, char *argv[])
 class MockPipelineContract : public PipelineContract
 {
 public:
-  MockPipelineContract(int32_t schemaVersion) : m_schemaVersion(schemaVersion) {}
-  DevicePtr findDevice(const std::string &) override { return nullptr; }
+  MockPipelineContract(int32_t schemaVersion, DataItemPtr &dataItem) : m_schemaVersion(schemaVersion), m_dataItem(dataItem) {}
+  DevicePtr findDevice(const std::string &) override { return m_device; }
   DataItemPtr findDataItem(const std::string &device, const std::string &name) override
   {
-    return nullptr;
+    return m_dataItem;
   }
   void eachDataItem(EachDataItem fun) override {}
   void deliverObservation(observation::ObservationPtr obs) override {}
@@ -61,6 +64,7 @@ public:
   void deliverDevices(std::list<DevicePtr>) override {}
   void deliverDevice(DevicePtr device) override {}
   int32_t getSchemaVersion() const override { return m_schemaVersion; }
+  bool hasValidation() const override { return m_validation; }
   void deliverAssetCommand(entity::EntityPtr) override {}
   void deliverCommand(entity::EntityPtr) override {}
   void deliverConnectStatus(entity::EntityPtr, const StringList &, bool) override {}
@@ -68,6 +72,9 @@ public:
   const ObservationPtr checkDuplicate(const ObservationPtr &obs) const override { return obs; }
 
   int32_t m_schemaVersion;
+  DataItemPtr &m_dataItem;
+  DevicePtr m_device;
+  bool m_validation { true };
 };
 
 /// @brief Validation tests for observations
@@ -76,15 +83,15 @@ class ObservationValidationTest : public testing::Test
 protected:
   void SetUp() override
   {
+    ErrorList errors;
+    m_dataItem =
+    DataItem::make({{"id", "exec"s}, {"category", "EVENT"s}, {"type", "EXECUTION"s}}, errors);
+
     m_context = make_shared<PipelineContext>();
-    m_context->m_contract = make_unique<MockPipelineContract>(SCHEMA_VERSION(2, 5));
+    m_context->m_contract = make_unique<MockPipelineContract>(SCHEMA_VERSION(2, 5), m_dataItem);
     m_validator = make_shared<Validator>(m_context);
     m_validator->bind(make_shared<NullTransform>(TypeGuard<Entity>(RUN)));
     m_time = Timestamp(date::sys_days(2021_y / jan / 19_d)) + 10h + 1min;
-
-    ErrorList errors;
-    m_dataItem =
-        DataItem::make({{"id", "exec"s}, {"category", "EVENT"s}, {"type", "EXECUTION"s}}, errors);
   }
 
   void TearDown() override
@@ -235,4 +242,128 @@ TEST_F(ObservationValidationTest, should_be_invalid_if_entry_has_not_been_introd
   auto quality = evt->get<string>("quality");
   ASSERT_EQ("INVALID", quality);
   ASSERT_FALSE(evt->hasProperty("deprecated"));
+}
+
+TEST_F(ObservationValidationTest, should_validate_data_item_types)
+{
+  auto contract = static_cast<MockPipelineContract *>(m_context->m_contract.get());
+  contract->m_schemaVersion = SCHEMA_VERSION(2, 5);
+  
+  shared_ptr<ShdrTokenMapper> mapper;
+  mapper = make_shared<ShdrTokenMapper>(m_context, "", 2);
+  mapper->bind(make_shared<NullTransform>(TypeGuard<Entity>(RUN)));
+
+  ErrorList errors;
+  m_dataItem =
+  DataItem::make({{"id", "pos"s}, {"category", "SAMPLE"s}, {"type", "POSITION"s}, {"units", "MILLIMETER"s}}, errors);
+
+  auto ts = make_shared<Timestamped>();
+  ts->m_tokens = {{"pos"s, "ABC"s}};
+  ts->m_timestamp = chrono::system_clock::now();
+  ts->setProperty("timestamp", ts->m_timestamp);
+
+  auto observations = (*mapper)(ts);
+  auto &r = *observations;
+  ASSERT_EQ(typeid(Observations), typeid(r));
+  
+  auto oblist = observations->getValue<EntityList>();
+  ASSERT_EQ(1, oblist.size());
+  
+  auto oi = oblist.begin();
+ 
+  {
+    auto sample = dynamic_pointer_cast<Sample>(*oi++);
+    ASSERT_TRUE(sample);
+    ASSERT_EQ(m_dataItem, sample->getDataItem());
+    ASSERT_TRUE(sample->isUnavailable());
+    
+    ASSERT_EQ("INVALID", sample->get<string>("quality"));
+  }
+
+}
+
+TEST_F(ObservationValidationTest, should_not_validate_if_validation_is_off)
+{
+  auto contract = static_cast<MockPipelineContract *>(m_context->m_contract.get());
+  contract->m_schemaVersion = SCHEMA_VERSION(2, 5);
+  contract->m_validation = false;
+  
+  shared_ptr<ShdrTokenMapper> mapper;
+  mapper = make_shared<ShdrTokenMapper>(m_context, "", 2);
+  mapper->bind(make_shared<NullTransform>(TypeGuard<Entity>(RUN)));
+  
+  ErrorList errors;
+  m_dataItem =
+  DataItem::make({{"id", "pos"s}, {"category", "SAMPLE"s}, {"type", "POSITION"s}, {"units", "MILLIMETER"s}}, errors);
+  
+  auto ts = make_shared<Timestamped>();
+  ts->m_tokens = {{"pos"s, "ABC"s}};
+  ts->m_timestamp = chrono::system_clock::now();
+  ts->setProperty("timestamp", ts->m_timestamp);
+  
+  auto observations = (*mapper)(ts);
+  auto &r = *observations;
+  ASSERT_EQ(typeid(Observations), typeid(r));
+  
+  auto oblist = observations->getValue<EntityList>();
+  ASSERT_EQ(1, oblist.size());
+  
+  auto oi = oblist.begin();
+  
+  {
+    auto sample = dynamic_pointer_cast<Sample>(*oi++);
+    ASSERT_TRUE(sample);
+    ASSERT_EQ(m_dataItem, sample->getDataItem());
+    ASSERT_TRUE(sample->isUnavailable());
+    
+    ASSERT_FALSE(sample->hasProperty("quality"));
+  }
+  
+}
+
+TEST_F(ObservationValidationTest, should_validate_json_data_item_types)
+{
+  using namespace mtconnect::device_model;
+  
+  ErrorList errors;
+  auto contract = static_cast<MockPipelineContract *>(m_context->m_contract.get());
+  contract->m_schemaVersion = SCHEMA_VERSION(2, 5);
+  Properties dev {
+    {"id", "3"s}, {"name", "DeviceTest2"s}, {"uuid", "UnivUniqId2"s}, {"iso841Class", "6"s}};
+  auto device = dynamic_pointer_cast<Device>(Device::getFactory()->make("Device", dev, errors));
+
+  
+  shared_ptr<JsonMapper> mapper;
+  mapper = make_shared<JsonMapper>(m_context);
+  mapper->bind(make_shared<NullTransform>(TypeGuard<Entity>(RUN)));
+  
+  m_dataItem =
+  DataItem::make({{"id", "pos"s}, {"category", "SAMPLE"s}, {"type", "POSITION"s}, {"units", "MILLIMETER"s}}, errors);
+  contract->m_dataItem = m_dataItem;
+  device->addDataItem(m_dataItem, errors);
+  ASSERT_EQ(0, errors.size());
+  
+  auto jm = make_shared<JsonMessage>();
+  jm->setValue(R"(
+{
+  "timestamp": "2023-11-09T11:20:00Z",
+  "pos": "ABC"
+}
+)"s);
+  jm->m_device = device;
+  
+  auto observations = (*mapper)(jm);  
+  auto oblist = observations->getValue<EntityList>();
+  ASSERT_EQ(1, oblist.size());
+  
+  auto oi = oblist.begin();
+  
+  {
+    auto sample = dynamic_pointer_cast<Sample>(*oi++);
+    ASSERT_TRUE(sample);
+    ASSERT_EQ(m_dataItem, sample->getDataItem());
+    ASSERT_TRUE(sample->isUnavailable());
+    
+    ASSERT_EQ("INVALID", sample->get<string>("quality"));
+  }  
 }


### PR DESCRIPTION
* Validate that timestamps are always moving forward. (When `CorrectTimestamps` options is on)
* Validate that SHDR and JSON value are have correct values for the data item during conversion.
  * If the value cannot be converted, set it to `UNAVAILABLE` and set the `quality` to `INVALID` 