### PR TITLE
Suggest update to correct the issue "Webocket does not respond to asset or assets request #578"

### DIFF
--- a/src/mtconnect/sink/rest_sink/rest_service.cpp
+++ b/src/mtconnect/sink/rest_sink/rest_service.cpp
@@ -531,8 +531,8 @@ namespace mtconnect {
         request->m_request = "MTConnectAssets";
 
         respond(session,
-                assetRequest(printer, count, removed, request->parameter<string>("type"),
-                             request->parameter<string>("device"), pretty, request->m_requestId),
+                assetRequest(printer,  count, removed, request->parameter<string>("type"),
+                          request->parameter<string>("device"),  pretty, request->m_requestId),
                 request->m_requestId);
         return true;
       };
@@ -567,22 +567,25 @@ namespace mtconnect {
       string qp(
           "type={string}&removed={bool:false}&"
           "count={integer:100}&device={string}&pretty={bool:false}&format={string}");
-      m_server->addRouting({boost::beast::http::verb::get, "/assets?" + qp, handler})
-          .document("MTConnect assets request", "Returns up to `count` assets");
       m_server->addRouting({boost::beast::http::verb::get, "/asset?" + qp, handler})
+          .document("MTConnect assets request", "Returns up to `count` assets");
+      m_server->addRouting({boost::beast::http::verb::get, "/{device}/asset?" + qp, handler})
+          .document("MTConnect assets request", "Returns up to `count` assets for deivce `device`")
+          .command("asset");
+      m_server->addRouting({boost::beast::http::verb::get, "/assets?" + qp, handler})
           .document("MTConnect asset request", "Returns up to `count` assets");
       m_server->addRouting({boost::beast::http::verb::get, "/{device}/assets?" + qp, handler})
-          .document("MTConnect assets request", "Returns up to `count` assets for deivce `device`");
-      m_server->addRouting({boost::beast::http::verb::get, "/{device}/asset?" + qp, handler})
-          .document("MTConnect asset request", "Returns up to `count` assets for deivce `device`");
-      m_server->addRouting({boost::beast::http::verb::get, "/assets/{assetIds}", idHandler})
+          .document("MTConnect asset request", "Returns up to `count` asset for deivce `device`")
+          .command("assets");
+      m_server->addRouting({boost::beast::http::verb::get, "/asset/{assetIds}", idHandler})
           .document(
               "MTConnect assets request",
               "Returns a set assets identified by asset ids `asset` separated by semi-colon (;)");
-      m_server->addRouting({boost::beast::http::verb::get, "/asset/{assetIds}", idHandler})
+      m_server->addRouting({boost::beast::http::verb::get, "/assets/{assetIds}", idHandler})
           .document("MTConnect asset request",
                     "Returns a set of assets identified by asset ids `asset` separated by "
-                    "semi-colon (;)");
+                    "semi-colon (;)")
+		  .command("assetsById");
 
       if (m_server->arePutsAllowed())
       {

--- a/src/mtconnect/sink/rest_sink/websocket_session.hpp
+++ b/src/mtconnect/sink/rest_sink/websocket_session.hpp
@@ -383,10 +383,12 @@ namespace mtconnect::sink::rest_sink {
 
               break;
             case rapidjson::kNumberType:
-              if (it.value.IsInt())
+              if (it.value.IsInt()){
                 request->m_parameters.emplace(
                     make_pair(it.name.GetString(), ParameterValue(it.value.GetInt())));
-              else if (it.value.IsUint())
+                    LOG(debug) << "int - " << it.name.GetString() << " value: " << it.value.GetInt();
+                  }
+              else if (it.value.IsUint()) 
                 request->m_parameters.emplace(
                     make_pair(it.name.GetString(), ParameterValue(uint64_t(it.value.GetUint()))));
               else if (it.value.IsInt64())
@@ -402,6 +404,19 @@ namespace mtconnect::sink::rest_sink {
               break;
           }
         }
+      }
+
+      int count = *request->parameter<int32_t>("count");
+
+      if ( !request->parameter<int32_t>("count") && *request->parameter<string>("request") == "sample") 
+        request->m_parameters["count"] = 100;
+
+      LOG(debug) << "request: " << *request->parameter<string>("request") << "| count: " << *request->parameter<int>("count");
+
+      auto asset = request->parameter<string>("assetIds");
+      if (asset)
+      {
+          request->m_parameters["request"] = "assetsById";
       }
 
       return request;


### PR DESCRIPTION
 Changes to be committed:
	modified:   ../../../src/mtconnect/sink/rest_sink/rest_service.cpp
	modified:   ../../../src/mtconnect/sink/rest_sink/websocket_session.hpp

 added asset, assets and assetsById commands to the RestRervice::createAssetRoutings method
 modifed the WebsocketSession::parseRequest to
  - replace the asset and assets command with assetsById when the assetIds parameter has values
  - set the count parameter to 100 if the request is sample and the count parameter is empty.

Fixes -
 - websocket response to the asset and assets websocket requests.
 - websocket response to the assetsIds parameter.
 - websocket response to the sample command without the count parameter being specified.