### PR TITLE
Fix missing line break in usage text

### DIFF
--- a/src/mtconnect/configuration/service.cpp
+++ b/src/mtconnect/configuration/service.cpp
@@ -62,7 +62,6 @@ namespace mtconnect {
 #else
           R"(       install        Install the agent as a service.
        remove            Removes the agent service.
-
 )"
 #endif
           R"(       debug          Runs the agent on the command line with verbose logging

--- a/src/mtconnect/configuration/service.cpp
+++ b/src/mtconnect/configuration/service.cpp
@@ -46,9 +46,11 @@ namespace mtconnect {
     {
       printf(
 #ifndef _WINDOWS
-          "Usage: agent [help|daemonize|debug|run] [config-file]"
+          R"(Usage: agent [help|daemonize|debug|run] [config-file]
+)"
 #else
-          "Usage: agent [help|install|remove|debug|run] [config-file]"
+          R"(Usage: agent [help|install|remove|debug|run] [config-file]
+)"
 #endif
           R"(       help           Prints this message and exits
        version        Prints the agent version and exits

--- a/src/mtconnect/configuration/service.cpp
+++ b/src/mtconnect/configuration/service.cpp
@@ -61,7 +61,7 @@ namespace mtconnect {
 )"
 #else
           R"(       install        Install the agent as a service.
-       remove            Removes the agent service.
+       remove         Removes the agent service.
 )"
 #endif
           R"(       debug          Runs the agent on the command line with verbose logging


### PR DESCRIPTION

This line should end with a line break:
> `Usage: agent [help|install|remove|debug|run] [config-file]`

<img width="1185" height="229" alt="image" src="https://github.com/user-attachments/assets/f67301ca-7815-4dde-bfff-c6afdd5d2c49" />